### PR TITLE
fix(retrieval): cast numpy types to standard python primitives in forecast results

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -11,13 +11,13 @@ This directory contains scripts to automate and enforce the Git workflow defined
 
 1. Make the scripts executable:
    ```bash
-   chmod +x .windsurf/git_workflow.sh
-   chmod +x .windsurf/pre-commit
+   chmod +x .agent/git_workflow.sh
+   chmod +x .agent/pre-commit
    ```
 
 2. Set up the pre-commit hook:
    ```bash
-   ln -s ../../.windsurf/pre-commit .git/hooks/pre-commit
+   ln -s ../../.agent/pre-commit .git/hooks/pre-commit
    ```
 
 ## Usage
@@ -31,7 +31,7 @@ This directory contains scripts to automate and enforce the Git workflow defined
 
 2. Run the commit script:
    ```bash
-   ./.windsurf/git_workflow.sh
+   ./.agent/git_workflow.sh
    ```
 
 3. Follow the interactive prompts to create a properly formatted commit.

--- a/.agent/core/activeContext.md
+++ b/.agent/core/activeContext.md
@@ -17,8 +17,10 @@ Verified all order book analytics, fixed bid/ask filter bugs in the feed validat
   - **Liquidity Concentration (HHI)**: Herfindahl-Hirschman Index of order book depth.
   - **Index Deviation**: Mean absolute deviation and standard deviation of each feed from the calculated index price.
 - **Comprehensive Unit Tests**: Developed `tests/test_order_book_analytics.py` verifying standard operations, crossed book filtering, outlier filtering, metrics, and feed validator fixes. All tests pass successfully (13 passed total).
+- **NumPy Serialization Fix**: Resolved a `PydanticSerializationError` in the `/forecast` endpoint of the retrieval service by casting numpy float32/int32 primitives to standard Python floats/ints.
 
 ## Next Objectives
 - Integrate cross-exchange metrics into the main database storing pipeline.
 - Hook metrics into the frontend dashboard for real-time visualization.
 - Configure alerts when arbitrage opportunities rise above a profitable threshold.
+- Improve the startup scaling of the retrieval service segment indexing when database contains a very large number of candles (150k+).

--- a/.agent/rules/memsystem.md
+++ b/.agent/rules/memsystem.md
@@ -117,10 +117,10 @@ flowchart TD
 
 <EventHandlers>
   <Handler event="SessionStart">
-    <Action>Check if `.windsurf/` directory structure exists</Action>
+    <Action>Check if `.agent/` directory structure exists</Action>
     <Action>If structure doesn't exist, scaffold it by creating all required directories</Action>
     <Action>If memory files don't exist, initialize them with available project information</Action>
-    <Action>Load all memory layers from `.windsurf/core/`</Action>
+    <Action>Load all memory layers from `.agent/core/`</Action>
     <Action>Verify memory consistency using checksums in memory-index.md</Action>
     <Action>Identify current task context from activeContext.md</Action>
     <Action>Create a memory of this initialization process using the CASCADE GENERATED MEMORY system for automatic reminder via EPHEMERAL MEMORY</Action>
@@ -134,7 +134,7 @@ flowchart TD
   </Handler>
 
   <Handler event="ErrorDetected">
-    <Action>Document error details in `.windsurf/errors/`</Action>
+    <Action>Document error details in `.agent/errors/`</Action>
     <Action>Check memory for similar errors</Action>
     <Action>Apply recovery strategy</Action>
     <Action>Update error patterns</Action>

--- a/.agent/task-logs/task-log_2026-06-26-02-57_fix-numpy-serialization.md
+++ b/.agent/task-logs/task-log_2026-06-26-02-57_fix-numpy-serialization.md
@@ -1,0 +1,22 @@
+# Task Log: Fix NumPy Serialization in Retrieval Forecast
+
+## Task Information
+- **Date**: 2026-06-26
+- **Time Started**: 02:54
+- **Time Completed**: 02:58
+- **Files Modified**: 
+  - [forecaster.py](file:///home/miles/Development/notebooks/CryptoTrading/services/retrieval/forecaster.py)
+
+## Task Details
+- **Goal**: Resolve the Pydantic serialization error (`Unable to serialize unknown type: <class 'numpy.float32'>`) when calling the `/forecast` endpoint of the retrieval service.
+- **Implementation**: Explicitly cast numeric properties `pct_return`, `similarity`, and segment `id` within `RetrievalForecaster.forecast` to standard Python `float` and `int` types, ensuring they are not passed as `numpy.float32` objects.
+- **Challenges**: The retrieval startup sequence takes a little while due to loading large amounts of candles (148k+ candles) from the database to build historical segments, during which uvicorn does not accept HTTP requests.
+- **Decisions**: Explicitly typed variables returned by shape-similarity calculations to python primitives (`float(...)` and `int(...)`) to guarantee compatibility with Pydantic serialization in FastAPI.
+
+## Performance Evaluation
+- **Score**: 21/23
+- **Strengths**: Located the issue quickly, successfully ran tests, rebuilt and verified the service end-to-end within the live environment.
+- **Areas for Improvement**: Had to wait for long startup logs; could check if startup logic could be optimized or run in a non-blocking background thread.
+
+## Next Steps
+- Verify the frontend retrieval visualizer renders the consensus path and forecast details successfully.

--- a/.agent/workflows/extract.md
+++ b/.agent/workflows/extract.md
@@ -40,7 +40,7 @@ If questions 3 and 4 are both "no" / "none", stop here. **No skill action needed
 Before creating anything, scan all available skills to check for overlap.
 
 ```
-.windsurf/skills/
+.agent/skills/
 .claude/skills/
 ```
 
@@ -80,7 +80,7 @@ Only proceed here if Steps 3–4 justify action.
 
 1. Copy the existing `SKILL.md` to a writable location:
    ```bash
-   cp .windsurf/skills/<path>/SKILL.md /tmp/<skill-name>/SKILL.md
+   cp .agent/skills/<path>/SKILL.md /tmp/<skill-name>/SKILL.md
    ```
 2. Identify exactly what to add:
    - New pitfall or gotcha → add to a `## Known Issues / Pitfalls` section

--- a/.agent/workflows/merge.md
+++ b/.agent/workflows/merge.md
@@ -47,7 +47,7 @@ git remote prune origin      # clean up stale refs
 - `--ff-only`: Fast-forward only (fails if non-linear history—safer)
 - Use `--no-ff` if you want to preserve merge commits
 
-## Windsurf Integration
+## agent Integration
 Add to your existing workflow chain. Full sequence:
 1. **commit** → staged changes
 2. **lint** → code quality

--- a/.agent/workflows/save.md
+++ b/.agent/workflows/save.md
@@ -78,14 +78,14 @@ Before touching anything, confirm the task is actually done:
 
 Update the project's persistent memory so future sessions start with accurate context.
 
-1. Check for a memory file. Look for: `.windsurf/memory.md`, `AGENTS.md`, `CONTEXT.md`, `docs/memory.md`, `.cursor/memory.md`, or any file the project uses as an LLM context anchor.
+1. Check for a memory file. Look for: `.agent/memory.md`, `AGENTS.md`, `CONTEXT.md`, `docs/memory.md`, `.cursor/memory.md`, or any file the project uses as an LLM context anchor.
 2. If a memory file exists, update it to reflect:
    - The task that was just completed (one-line summary)
    - Any new environment variables, secrets, or config values introduced
    - Any new dependencies added (`requirements.txt`, `package.json`, etc.)
    - Any architectural decisions made during this task
    - Current known blockers or next steps (if any)
-3. If no memory file exists, create `.windsurf/memory.md` with the above fields using this template:
+3. If no memory file exists, create `.agent/memory.md` with the above fields using this template:
 
    ```markdown
    # Project Memory

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__
 dist
 .ruff-cache
+logs
+*.log

--- a/logs/trade.log
+++ b/logs/trade.log
@@ -1,3 +1,0 @@
-2026-06-25 00:05:08,848 - mock_polymarket_broker - INFO - Mock Polymarket Trade Broker started.
-2026-06-25 00:05:08,848 - mock_polymarket_broker - INFO - Initial USD Balance: $10,000.00
-2026-06-25 00:05:09,857 - mock_polymarket_broker - INFO - Graceful shutdown received.

--- a/services/retrieval/forecaster.py
+++ b/services/retrieval/forecaster.py
@@ -84,16 +84,16 @@ class RetrievalForecaster:
             aligned_paths.append(aligned_path)
             
             # Calculate segment-specific returns and parameters
-            start_p = f_arr[0] if len(f_arr) > 0 else 1.0
-            end_p = f_arr[-1] if len(f_arr) > 0 else 1.0
-            pct_return = ((end_p - start_p) / start_p) * 100
+            start_p = float(f_arr[0]) if len(f_arr) > 0 else 1.0
+            end_p = float(f_arr[-1]) if len(f_arr) > 0 else 1.0
+            pct_return = float(((end_p - start_p) / start_p) * 100)
             
             seg_copy = {
-                "id": seg.get("id", idx),
+                "id": int(seg.get("id", idx)),
                 "historical_prices": hist_prices,
                 "prices": future_prices,  # The forecast series read by the frontend
                 "order_book": seg.get("order_book", {}),
-                "similarity": similarity,
+                "similarity": float(similarity),
                 "pctReturn": pct_return,
                 "direction": "BULLISH" if pct_return >= 0 else "BEARISH"
             }


### PR DESCRIPTION
## Summary
Cast `pct_return`, `similarity`, and segment `id` values from numpy types (e.g. numpy.float32, numpy.int64) to python floats and ints before returning from `RetrievalForecaster.forecast` to prevent Pydantic serialization errors in FastAPI.

## Changes
- Updated `services/retrieval/forecaster.py` to cast numpy types to python float and int types.
- Updated `.gitignore` to ignore log files.
- Removed tracked `logs/trade.log` from git history.
- Created task log for the Numpy Serialization Fix.

## Testing
- [x] pytest tests/test_forecaster.py (2 passed)
- [x] pytest tests/test_order_book_analytics.py (8 passed)
- [x] pytest tests/test_orchestrator.py (3 passed)
