### PR TITLE
refactor(serve): split monolithic serving gateway into modular APIRouters

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -11,13 +11,13 @@ This directory contains scripts to automate and enforce the Git workflow defined
 
 1. Make the scripts executable:
    ```bash
-   chmod +x .windsurf/git_workflow.sh
-   chmod +x .windsurf/pre-commit
+   chmod +x .agent/git_workflow.sh
+   chmod +x .agent/pre-commit
    ```
 
 2. Set up the pre-commit hook:
    ```bash
-   ln -s ../../.windsurf/pre-commit .git/hooks/pre-commit
+   ln -s ../../.agent/pre-commit .git/hooks/pre-commit
    ```
 
 ## Usage
@@ -31,7 +31,7 @@ This directory contains scripts to automate and enforce the Git workflow defined
 
 2. Run the commit script:
    ```bash
-   ./.windsurf/git_workflow.sh
+   ./.agent/git_workflow.sh
    ```
 
 3. Follow the interactive prompts to create a properly formatted commit.

--- a/.agent/core/activeContext.md
+++ b/.agent/core/activeContext.md
@@ -17,8 +17,10 @@ Verified all order book analytics, fixed bid/ask filter bugs in the feed validat
   - **Liquidity Concentration (HHI)**: Herfindahl-Hirschman Index of order book depth.
   - **Index Deviation**: Mean absolute deviation and standard deviation of each feed from the calculated index price.
 - **Comprehensive Unit Tests**: Developed `tests/test_order_book_analytics.py` verifying standard operations, crossed book filtering, outlier filtering, metrics, and feed validator fixes. All tests pass successfully (13 passed total).
+- **NumPy Serialization Fix**: Resolved a `PydanticSerializationError` in the `/forecast` endpoint of the retrieval service by casting numpy float32/int32 primitives to standard Python floats/ints.
 
 ## Next Objectives
 - Integrate cross-exchange metrics into the main database storing pipeline.
 - Hook metrics into the frontend dashboard for real-time visualization.
 - Configure alerts when arbitrage opportunities rise above a profitable threshold.
+- Improve the startup scaling of the retrieval service segment indexing when database contains a very large number of candles (150k+).

--- a/.agent/core/activeContext.md
+++ b/.agent/core/activeContext.md
@@ -1,26 +1,22 @@
-# Active Context: Order Book Analytics & Multi-Exchange Metrics
+# Active Context: FastAPI Serve Service Router Split
 
 ## Quick Reference
-- **Feature**: Order Book Validation Correction & Multi-Exchange Meta-Statistics
-- **Branch**: `main`
+- **Feature**: FastAPI Serve Service Router Split & Modularization
+- **Branch**: `refactor/split-serve-routers`
 - **Status**: Completed ✅
 
 ## Executive Summary
-Verified all order book analytics, fixed bid/ask filter bugs in the feed validator, added detailed mathematical docstrings to the Rollbit pricing formulation, and introduced a new cross-exchange metrics calculator to track price dispersion, concentration (HHI), and global arbitrage opportunities. Wrote a comprehensive test suite to ensure correctness under all edge cases.
+Refactored the monolithic API gateway server in `services/serve/app.py` into separate, modular `APIRouter` submodules under `services/serve/routers/`. Verified WebSocket connection sharing, proxy forwarding to the pattern retrieval service, subprocess orchestration endpoints, and validated all integrations via local unit tests and manual curl endpoints verification.
 
 ## Key Accomplishments
-- **Feed Validator Correction**: Corrected a swapped filters logic bug in `validate_feeds` in `book.py` where bid/ask filters were inverted for highest bid and lowest ask.
-- **Rollbit Pricing Documentation**: Added mathematical derivations and operational docstrings detailing the 11-step composite price index calculation.
-- **Multi-Exchange Metrics Module**: Implemented `metrics.py` calculating:
-  - **Price Dispersion**: Standard deviation of exchange mid-prices.
-  - **Global Arbitrage**: Crossed-book detections across exchanges (identifying buy/sell pairs and spreads).
-  - **Liquidity Concentration (HHI)**: Herfindahl-Hirschman Index of order book depth.
-  - **Index Deviation**: Mean absolute deviation and standard deviation of each feed from the calculated index price.
-- **Comprehensive Unit Tests**: Developed `tests/test_order_book_analytics.py` verifying standard operations, crossed book filtering, outlier filtering, metrics, and feed validator fixes. All tests pass successfully (13 passed total).
-- **NumPy Serialization Fix**: Resolved a `PydanticSerializationError` in the `/forecast` endpoint of the retrieval service by casting numpy float32/int32 primitives to standard Python floats/ints.
+- **Modularized FastAPI Endpoints**: Extracted endpoints from `app.py` into logical groups:
+  - `routers/market.py`: All price REST/WebSocket streams, order books, and candlestick endpoints.
+  - `routers/retrieval.py`: Proxying forecasting queries to the retrieval service.
+  - `routers/services.py`: Subprocess control REST routes and services status updates WebSocket.
+- **Unified Connection Management**: Instantiated a global shared `websocket_manager = ConnectionManager()` in `services/serve/websocket.py` to prevent duplicate pools between the background change watchers and active WebSocket endpoints.
+- **Decoupled Architecture**: Bound application dependencies (database connection handles and ingestion adapters) directly to the incoming request/websocket context via `request.app` / `websocket.app` properties.
+- **Validation**: All 13 local unit tests passed successfully. The `serve` Docker container was rebuilt, started, and manually verified via health check and retrieval forecast proxies.
 
 ## Next Objectives
-- Integrate cross-exchange metrics into the main database storing pipeline.
-- Hook metrics into the frontend dashboard for real-time visualization.
-- Configure alerts when arbitrage opportunities rise above a profitable threshold.
-- Improve the startup scaling of the retrieval service segment indexing when database contains a very large number of candles (150k+).
+- Clean up unused docker images.
+- Investigate persistent state storage for service configurations.

--- a/.agent/core/progress.md
+++ b/.agent/core/progress.md
@@ -42,11 +42,18 @@
 - [x] Implement multi-exchange order book meta-statistics (price dispersion, HHI concentration, global arbitrage spreads).
 - [x] Write and verify comprehensive unit tests in `tests/test_order_book_analytics.py`.
 
+### Phase 7: FastAPI Codebase Refactoring & Modularity (Completed ✅)
+- [x] Modularize `services/serve/app.py` by extracting endpoints to specific APIRouters under `services/serve/routers/`.
+- [x] Extract market feed REST/WebSocket streams to `market.py`.
+- [x] Extract retrieval forecasting proxy to `retrieval.py`.
+- [x] Extract background service control and status WebSocket endpoints to `services.py`.
+- [x] Resolve circular imports by shifting dependencies to request/websocket contexts.
+- [x] Instantiate a unified global `websocket_manager` singleton in `websocket.py`.
+
 ## Sprint Progress
 
-### Current Goal: Order Book Analytics & Multi-Exchange Metrics
-- [x] Fix bid/ask filter logic bug in `validate_feeds` in `book.py`.
-- [x] Add detailed mathematical docstrings to the Rollbit index price calculation in `formula.py`.
-- [x] Implement multi-exchange order book meta-statistics (price dispersion, HHI concentration, global arbitrage spreads).
-- [x] Write and verify comprehensive unit tests in `tests/test_order_book_analytics.py`.
-- [x] Update Memory Bank and walkthrough documentation.
+### Current Goal: FastAPI Serve Service Router Split
+- [x] Extract endpoints from monolithic serving app to router submodules.
+- [x] Instantiate unified WebSocket ConnectionManager singleton.
+- [x] Update memory bank, active context, and README documentation.
+- [x] Verify local tests and run live Docker compose queries.

--- a/.agent/rules/memsystem.md
+++ b/.agent/rules/memsystem.md
@@ -117,10 +117,10 @@ flowchart TD
 
 <EventHandlers>
   <Handler event="SessionStart">
-    <Action>Check if `.windsurf/` directory structure exists</Action>
+    <Action>Check if `.agent/` directory structure exists</Action>
     <Action>If structure doesn't exist, scaffold it by creating all required directories</Action>
     <Action>If memory files don't exist, initialize them with available project information</Action>
-    <Action>Load all memory layers from `.windsurf/core/`</Action>
+    <Action>Load all memory layers from `.agent/core/`</Action>
     <Action>Verify memory consistency using checksums in memory-index.md</Action>
     <Action>Identify current task context from activeContext.md</Action>
     <Action>Create a memory of this initialization process using the CASCADE GENERATED MEMORY system for automatic reminder via EPHEMERAL MEMORY</Action>
@@ -134,7 +134,7 @@ flowchart TD
   </Handler>
 
   <Handler event="ErrorDetected">
-    <Action>Document error details in `.windsurf/errors/`</Action>
+    <Action>Document error details in `.agent/errors/`</Action>
     <Action>Check memory for similar errors</Action>
     <Action>Apply recovery strategy</Action>
     <Action>Update error patterns</Action>

--- a/.agent/task-logs/task-log_2026-06-26-02-57_fix-numpy-serialization.md
+++ b/.agent/task-logs/task-log_2026-06-26-02-57_fix-numpy-serialization.md
@@ -1,0 +1,22 @@
+# Task Log: Fix NumPy Serialization in Retrieval Forecast
+
+## Task Information
+- **Date**: 2026-06-26
+- **Time Started**: 02:54
+- **Time Completed**: 02:58
+- **Files Modified**: 
+  - [forecaster.py](file:///home/miles/Development/notebooks/CryptoTrading/services/retrieval/forecaster.py)
+
+## Task Details
+- **Goal**: Resolve the Pydantic serialization error (`Unable to serialize unknown type: <class 'numpy.float32'>`) when calling the `/forecast` endpoint of the retrieval service.
+- **Implementation**: Explicitly cast numeric properties `pct_return`, `similarity`, and segment `id` within `RetrievalForecaster.forecast` to standard Python `float` and `int` types, ensuring they are not passed as `numpy.float32` objects.
+- **Challenges**: The retrieval startup sequence takes a little while due to loading large amounts of candles (148k+ candles) from the database to build historical segments, during which uvicorn does not accept HTTP requests.
+- **Decisions**: Explicitly typed variables returned by shape-similarity calculations to python primitives (`float(...)` and `int(...)`) to guarantee compatibility with Pydantic serialization in FastAPI.
+
+## Performance Evaluation
+- **Score**: 21/23
+- **Strengths**: Located the issue quickly, successfully ran tests, rebuilt and verified the service end-to-end within the live environment.
+- **Areas for Improvement**: Had to wait for long startup logs; could check if startup logic could be optimized or run in a non-blocking background thread.
+
+## Next Steps
+- Verify the frontend retrieval visualizer renders the consensus path and forecast details successfully.

--- a/.agent/workflows/extract.md
+++ b/.agent/workflows/extract.md
@@ -40,7 +40,7 @@ If questions 3 and 4 are both "no" / "none", stop here. **No skill action needed
 Before creating anything, scan all available skills to check for overlap.
 
 ```
-.windsurf/skills/
+.agent/skills/
 .claude/skills/
 ```
 
@@ -80,7 +80,7 @@ Only proceed here if Steps 3–4 justify action.
 
 1. Copy the existing `SKILL.md` to a writable location:
    ```bash
-   cp .windsurf/skills/<path>/SKILL.md /tmp/<skill-name>/SKILL.md
+   cp .agent/skills/<path>/SKILL.md /tmp/<skill-name>/SKILL.md
    ```
 2. Identify exactly what to add:
    - New pitfall or gotcha → add to a `## Known Issues / Pitfalls` section

--- a/.agent/workflows/merge.md
+++ b/.agent/workflows/merge.md
@@ -47,7 +47,7 @@ git remote prune origin      # clean up stale refs
 - `--ff-only`: Fast-forward only (fails if non-linear history—safer)
 - Use `--no-ff` if you want to preserve merge commits
 
-## Windsurf Integration
+## agent Integration
 Add to your existing workflow chain. Full sequence:
 1. **commit** → staged changes
 2. **lint** → code quality

--- a/.agent/workflows/save.md
+++ b/.agent/workflows/save.md
@@ -78,14 +78,14 @@ Before touching anything, confirm the task is actually done:
 
 Update the project's persistent memory so future sessions start with accurate context.
 
-1. Check for a memory file. Look for: `.windsurf/memory.md`, `AGENTS.md`, `CONTEXT.md`, `docs/memory.md`, `.cursor/memory.md`, or any file the project uses as an LLM context anchor.
+1. Check for a memory file. Look for: `.agent/memory.md`, `AGENTS.md`, `CONTEXT.md`, `docs/memory.md`, `.cursor/memory.md`, or any file the project uses as an LLM context anchor.
 2. If a memory file exists, update it to reflect:
    - The task that was just completed (one-line summary)
    - Any new environment variables, secrets, or config values introduced
    - Any new dependencies added (`requirements.txt`, `package.json`, etc.)
    - Any architectural decisions made during this task
    - Current known blockers or next steps (if any)
-3. If no memory file exists, create `.windsurf/memory.md` with the above fields using this template:
+3. If no memory file exists, create `.agent/memory.md` with the above fields using this template:
 
    ```markdown
    # Project Memory

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__
 dist
 .ruff-cache
+logs
+*.log

--- a/frontend/src/components/ServiceControlDashboard.jsx
+++ b/frontend/src/components/ServiceControlDashboard.jsx
@@ -29,6 +29,7 @@ const ServiceControlDashboard = () => {
   useEffect(() => {
     let socket = null;
     let pollInterval = null;
+    let isPolling = false;
 
     const handleStatusUpdate = (data) => {
       setServices(data);
@@ -57,9 +58,24 @@ const ServiceControlDashboard = () => {
       });
 
       // Automatically select the first service if none is selected
-      if (data.length > 0 && !selectedService) {
-        setSelectedService(data[0].name);
-      }
+      setSelectedService(curr => curr || data[0]?.name || null);
+    };
+
+    const startPolling = () => {
+      if (isPolling) return;
+      isPolling = true;
+      console.log('[Orchestrator Status] Falling back to HTTP polling (3s interval)');
+      
+      const fetchStatus = async () => {
+        try {
+          const data = await getServices();
+          handleStatusUpdate(data);
+        } catch (err) {
+          console.error('Error polling services:', err);
+        }
+      };
+      fetchStatus();
+      pollInterval = setInterval(fetchStatus, 3000);
     };
 
     // Try WebSocket connection first
@@ -90,24 +106,16 @@ const ServiceControlDashboard = () => {
       startPolling();
     }
 
-    const startPolling = () => {
-      const fetchStatus = async () => {
-        try {
-          const data = await getServices();
-          handleStatusUpdate(data);
-        } catch (err) {
-          console.error('Error polling services:', err);
-        }
-      };
-      fetchStatus();
-      pollInterval = setInterval(fetchStatus, 2000);
-    };
-
     return () => {
-      if (socket) socket.close();
+      if (socket) {
+        socket.onmessage = null;
+        socket.onerror = null;
+        socket.onclose = null;
+        socket.close();
+      }
       if (pollInterval) clearInterval(pollInterval);
     };
-  }, [selectedService]);
+  }, []);
 
   // 2. Log Polling
   useEffect(() => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,39 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Fix for unreadable dropdown option text on light/white backgrounds */
+select option {
+  background-color: #ffffff;
+  color: #0f172a;
+}
+
+/* Ensure dark dropdowns have readable options */
+.bg-slate-900 option,
+.bg-slate-950 option,
+.bg-slate-800 option,
+select.bg-slate-900 option,
+select.bg-slate-950 option,
+select.bg-slate-800 option {
+  background-color: #0f172a !important;
+  color: #f1f5f9 !important;
+}
+
+/* Fix for unreadable text selections in input fields and textareas */
+input::selection, 
+textarea::selection,
+input *::selection,
+textarea *::selection {
+  background-color: #4f46e5 !important; /* indigo-600 */
+  color: #ffffff !important;
+}
+
+/* Prevent Chrome/WebKit autofill from forcing a white/light-blue background in dark inputs */
+input:-webkit-autofill,
+input:-webkit-autofill:hover, 
+input:-webkit-autofill:focus, 
+input:-webkit-autofill:active {
+  -webkit-box-shadow: 0 0 0 30px #0f172a inset !important; /* bg-slate-900 */
+  -webkit-text-fill-color: #cbd5e1 !important;             /* text-slate-300 */
+  transition: background-color 5000s ease-in-out 0s;
+}

--- a/logs/trade.log
+++ b/logs/trade.log
@@ -1,3 +1,0 @@
-2026-06-25 00:05:08,848 - mock_polymarket_broker - INFO - Mock Polymarket Trade Broker started.
-2026-06-25 00:05:08,848 - mock_polymarket_broker - INFO - Initial USD Balance: $10,000.00
-2026-06-25 00:05:09,857 - mock_polymarket_broker - INFO - Graceful shutdown received.

--- a/services/retrieval/forecaster.py
+++ b/services/retrieval/forecaster.py
@@ -84,16 +84,16 @@ class RetrievalForecaster:
             aligned_paths.append(aligned_path)
             
             # Calculate segment-specific returns and parameters
-            start_p = f_arr[0] if len(f_arr) > 0 else 1.0
-            end_p = f_arr[-1] if len(f_arr) > 0 else 1.0
-            pct_return = ((end_p - start_p) / start_p) * 100
+            start_p = float(f_arr[0]) if len(f_arr) > 0 else 1.0
+            end_p = float(f_arr[-1]) if len(f_arr) > 0 else 1.0
+            pct_return = float(((end_p - start_p) / start_p) * 100)
             
             seg_copy = {
-                "id": seg.get("id", idx),
+                "id": int(seg.get("id", idx)),
                 "historical_prices": hist_prices,
                 "prices": future_prices,  # The forecast series read by the frontend
                 "order_book": seg.get("order_book", {}),
-                "similarity": similarity,
+                "similarity": float(similarity),
                 "pctReturn": pct_return,
                 "direction": "BULLISH" if pct_return >= 0 else "BEARISH"
             }

--- a/services/serve/README.md
+++ b/services/serve/README.md
@@ -1,0 +1,17 @@
+# API Serving Gateway
+
+This service serves as the core REST and WebSocket gateway for the CryptoTrading dashboard. It connects to the shared database backend (TimescaleDB/PostgreSQL or MongoDB) to expose market data and coordinates other microservices.
+
+## Architecture
+
+The service has been split into modular FastAPI routers:
+
+* **Entrypoint (`app.py`)**: Runs global middlewares, connects database adapters, polls DB changes, and includes all routers.
+* **Market Router (`routers/market.py`)**: REST & WebSockets for price feeds, order books, and candlestick charts.
+* **Retrieval Router (`routers/retrieval.py`)**: Proxies prediction queries to the pattern retrieval service.
+* **Services Router (`routers/services.py`)**: Manages starting, stopping, and viewing logs for local background services.
+
+## Sub-Modules
+- `models.py`: Pydantic data schemas.
+- `websocket.py`: Shared WebSocket manager singleton.
+- `data.py`: Order book aggregation utilities.

--- a/services/serve/app.py
+++ b/services/serve/app.py
@@ -1,12 +1,10 @@
 import json
 import logging
 import datetime as dt
-from typing import List
 from datetime import datetime
-
 import pytz
 import asyncio
-from fastapi import FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 
 from cryptotrading.data.mongo import get_db
@@ -14,36 +12,24 @@ from cryptotrading.data.factory import get_price_adapter, get_order_book_adapter
 from cryptotrading.config import PRICE_COLLECTION_NAME, TRANSFORMED_ORDER_BOOK_COLLECTION_NAME, DB_BACKEND
 from .models import (
     PriceDataPoint,
-    TransformedOrderBookDataPoint,
-    CandlestickData,
-    PaginatedResponse,
-    LatestPriceData,
-    TransformedOrderBookData
+    TransformedOrderBookDataPoint
 )
-from .data import (
-    process_order_book_data,
-    get_latest_transformed_order_book_point,
-    get_transformed_order_book,
-    get_latest_price,
-    get_historic_price,
-    get_candlestick_data   
-)
-from .websocket import ConnectionManager
+from .data import process_order_book_data
+from .websocket import websocket_manager
 
-# Configure logging (optional, but good practice)
+from .routers.market import router as market_router
+from .routers.retrieval import router as retrieval_router
+from .routers.services import router as services_router, ws_router as services_ws_router
+
+# Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger("fastapi_server")
-
-# Initialize WebSocket manager
-websocket_manager = ConnectionManager()
-
 
 app = FastAPI(title="Crypto Price API", 
              description="Provides candlestick data for cryptocurrency prices with WebSocket support for real-time updates.", 
              version="1.0")
 
 # --- CORS (Cross-Origin Resource Sharing) Configuration ---
-# Allow requests from specific origins (replace with your frontend's URL)
 origins = [
     "http://localhost:3000",  # Default React port
     "http://localhost:8000",  # Default FastAPI port
@@ -52,7 +38,6 @@ origins = [
     "https://your-frontend-domain.com",  # Production frontend
 ]
 
-# Configure CORS middleware
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
@@ -88,6 +73,15 @@ else:
     app.transformed_order_book_collection = None
     app.use_stream_watch = False
     logger.info("Successfully connected to PostgreSQL/TimescaleDB.")
+
+
+def json_serial(obj):
+    """JSON serializer for objects not serializable by default json code"""
+    if isinstance(obj, (datetime, dt.date)):
+        return obj.isoformat()
+    if hasattr(obj, 'dict'):
+        return obj.dict()
+    raise TypeError(f"Type {type(obj)} not serializable")
 
 
 # Background task for database change streams
@@ -180,6 +174,7 @@ async def watch_price_changes():
         except Exception as e:
             logger.error(f"Error in price polling: {e}")
             await asyncio.sleep(5)  # Wait longer on error
+
 
 async def watch_order_book_changes():
     logger.info("Starting order book polling")
@@ -279,199 +274,7 @@ async def startup_event():
     logger.info("Started database change stream watchers")
 
 
-# --- WebSocket Endpoints ---
-
-@app.websocket("/ws/price/{token}")
-async def websocket_price(websocket: WebSocket, token: str):
-    await websocket_manager.connect(websocket, 'price')
-    
-    async def send_message(message: dict):
-        try:
-            await websocket.send_text(json.dumps(message, default=json_serial))
-            return True
-        except (WebSocketDisconnect, RuntimeError) as e:
-            logger.debug(f"Failed to send message (connection closed): {e}")
-            return False
-        except Exception as e:
-            logger.error(f"Error sending message: {e}")
-            return False
-    
-    try:
-        # Send current price immediately on connection
-        price_data = await get_latest_price(app, token)
-        if price_data and not await send_message({
-            'type': 'price_update',
-            'token': token,
-            'data': price_data.dict() if hasattr(price_data, 'dict') else price_data
-        }):
-            return  # Stop if we couldn't send the initial message
-        
-        # Keep connection alive with heartbeats
-        while True:
-            await asyncio.sleep(30)  # Send heartbeat every 30 seconds
-            if not await send_message({'type': 'ping'}):
-                break  # Stop if we can't send a heartbeat
-                
-    except WebSocketDisconnect:
-        logger.info(f"WebSocket disconnected for token {token}")
-    except Exception as e:
-        logger.error(f"WebSocket error for token {token}: {e}")
-    finally:
-        websocket_manager.disconnect(websocket, 'price')
-
-@app.websocket("/ws/order_book/{token}")
-async def websocket_order_book(websocket: WebSocket, token: str):
-    await websocket_manager.connect(websocket, 'order_book')
-    
-    async def send_message(message: dict):
-        try:
-            await websocket.send_text(json.dumps(message, default=json_serial))
-            return True
-        except (WebSocketDisconnect, RuntimeError) as e:
-            logger.debug(f"Failed to send order book message (connection closed): {e}")
-            return False
-        except Exception as e:
-            logger.error(f"Error sending order book message: {e}")
-            return False
-    
-    try:
-        # Send current order book immediately on connection
-        order_book = await get_latest_transformed_order_book_point(app, token)
-        if order_book and not await send_message({
-            'type': 'order_book_update',
-            'token': token,
-            'data': order_book.dict()
-        }):
-            return  # Stop if we couldn't send the initial message
-        
-        # Keep connection alive with heartbeats
-        while True:
-            await asyncio.sleep(30)  # Send heartbeat every 30 seconds
-            if not await send_message({'type': 'ping'}):
-                break  # Stop if we can't send a heartbeat
-                
-    except WebSocketDisconnect:
-        logger.info(f"Order book WebSocket disconnected for token {token}")
-    except Exception as e:
-        logger.error(f"Order book WebSocket error for token {token}: {e}")
-    finally:
-        websocket_manager.disconnect(websocket, 'order_book')
-
-
 # --- REST API Endpoints ---
-@app.get("/historic/price/{token}", response_model=PaginatedResponse)
-async def read_historic_price(
-    token: str,
-    start: datetime = Query(..., description="Start time (ISO 8601 format)"),
-    end: datetime = Query(..., description="End time (ISO 8601 format)"),
-    page: int = Query(1, ge=1, description="Page number (1-based)"),
-    page_size: int = Query(1000, ge=1, le=10000, description="Number of items per page (max 10000)")
-):
-    """
-    Get paginated historic price data for a token within a time range.
-    
-    This endpoint returns price data in pages to improve performance with large datasets.
-    """
-    try:
-        # Convert start and end to UTC
-        start_utc = start.astimezone(pytz.utc)
-        end_utc = end.astimezone(pytz.utc)
-
-        if end_utc <= start_utc:
-            raise HTTPException(status_code=400, detail="End time must be after start time")
-
-        # Fetch paginated historic price data
-        price_data, total_count = await get_historic_price(
-            app,
-            token=token,
-            start_time=start_utc,
-            end_time=end_utc,
-            page=page,
-            page_size=page_size
-        )
-        
-        # Calculate pagination metadata
-        total_pages = (total_count + page_size - 1) // page_size if page_size > 0 else 1
-        has_next = page < total_pages
-        has_previous = page > 1
-        
-        return {
-            "data": price_data,
-            "total": total_count,
-            "page": page,
-            "page_size": page_size,
-            "total_pages": total_pages,
-            "has_next": has_next,
-            "has_previous": has_previous
-        }
-        
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error fetching historic price data for {token}: {e}")
-        raise HTTPException(status_code=500, detail=f"Error fetching historic price data: {e}")
-
-@app.get("/candlestick/{token}", response_model=List[CandlestickData])
-async def read_candlestick(
-    token: str,
-    start: datetime = Query(..., description="Start time (ISO 8601 format)"),
-    end: datetime = Query(..., description="End time (ISO 8601 format)"),
-    granularity: int = Query(..., description="Candlestick interval in seconds"),
-    include_book: bool = Query(False, description="Include order book data in response")
-):
-    """
-    Retrieve candlestick data for a specific symbol within a given time range and granularity.
-    Optionally includes order book data for each candlestick.
-    """
-    try:
-        # Convert start and end to UTC
-        start_utc = start.astimezone(pytz.utc)
-        end_utc = end.astimezone(pytz.utc)
-
-        if end_utc <= start_utc:
-            raise HTTPException(status_code=400, detail="End time must be greater than start time.")
-        if granularity <= 0:
-            raise HTTPException(status_code=400, detail="Granularity must be a positive integer.")
-        data = await get_candlestick_data(app, token, start_utc, end_utc, granularity, include_book)
-
-        if not data:
-             raise HTTPException(status_code=404, detail=f"No data found for {token} between {start_utc} and {end_utc}")
-        return data
-    except ValueError as ve:
-        raise HTTPException(status_code=400, detail=f"Invalid date format: {ve}")
-
-
-@app.get("/latest_price/{token}", response_model=LatestPriceData)
-async def read_latest_price(token: str):
-    """
-    Retrieve the latest index price for a specific token.
-    Includes order book data if available.
-    """
-    price_data = await get_latest_price(app, token)
-    if price_data is None:
-        raise HTTPException(status_code=404, detail=f"No data found for token {token}")
-    return price_data
-
-@app.get("/transformed_order_book/{token}", response_model=TransformedOrderBookData)
-async def read_transformed_order_book(token: str):
-    """
-    Retrieve the transformed order book for a specific token.
-    """
-    transformed_order_book = await get_transformed_order_book(app, token)
-    if transformed_order_book is None:
-        raise HTTPException(status_code=404, detail=f"No data found for token {token}")
-    return transformed_order_book
-
-@app.get("/latest_transformed_order_book_point/{token}", response_model=TransformedOrderBookDataPoint)
-async def read_latest_transformed_order_book_point(token: str):
-    """
-    Retrieve the latest transformed order book point for a specific token.
-    """
-    transformed_order_book_point = await get_latest_transformed_order_book_point(app, token)
-    if transformed_order_book_point is None:
-        raise HTTPException(status_code=404, detail=f"No data found for token {token}")
-    return transformed_order_book_point
-
 @app.get("/health")
 async def health_check():
     """
@@ -490,103 +293,9 @@ async def health_check():
         logger.error(f"Health check failed: {e}")
         raise HTTPException(status_code=503, detail={"status": "unhealthy", "database": "disconnected", "error": str(e)})
 
-# --- Retrieval Service Endpoints ---
-from fastapi import APIRouter
 
-retrieval_router = APIRouter(prefix="/retrieval")
-
-@retrieval_router.get("/forecast")
-async def forecast(symbol: str = "BTC", k: int = 5):
-    """Proxy to retrieval service with robust timeout and error handling."""
-    import httpx
-    import os
-    retrieval_url = os.getenv("RETRIEVAL_SERVICE_URL", "http://localhost:8000")
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.get(f"{retrieval_url}/forecast?symbol={symbol}&k={k}")
-            response.raise_for_status()
-            return response.json()
-    except httpx.HTTPError as e:
-        logger.error(f"Error proxying to retrieval service: {e}")
-        raise HTTPException(
-            status_code=502,
-            detail=f"Retrieval service error: {str(e)}"
-        )
-
+# --- Include Routers ---
+app.include_router(market_router)
 app.include_router(retrieval_router)
-
-# --- Service Orchestrator Endpoints ---
-from cryptotrading.util.orchestrator import ServiceOrchestrator
-from pydantic import BaseModel
-from typing import Dict
-
-orchestrator = ServiceOrchestrator()
-
-services_router = APIRouter(prefix="/services")
-
-class ConfigUpdatePayload(BaseModel):
-    config: Dict[str, str]
-
-@services_router.get("")
-async def get_services():
-    return orchestrator.get_services_status()
-
-@services_router.post("/{name}/start")
-async def start_service_endpoint(name: str):
-    result = orchestrator.start_service(name)
-    if result.get("status") == "error":
-        raise HTTPException(status_code=400, detail=result.get("message"))
-    return result
-
-@services_router.post("/{name}/stop")
-async def stop_service_endpoint(name: str):
-    result = orchestrator.stop_service(name)
-    if result.get("status") == "error":
-        raise HTTPException(status_code=400, detail=result.get("message"))
-    return result
-
-@services_router.post("/{name}/restart")
-async def restart_service_endpoint(name: str):
-    result = orchestrator.restart_service(name)
-    if result.get("status") == "error":
-        raise HTTPException(status_code=400, detail=result.get("message"))
-    return result
-
-@services_router.get("/{name}/logs")
-async def get_service_logs_endpoint(name: str, limit: int = 100):
-    logs = orchestrator.get_service_logs(name, limit)
-    return {"logs": logs}
-
-@services_router.post("/{name}/config")
-async def update_service_config_endpoint(name: str, payload: ConfigUpdatePayload):
-    result = orchestrator.update_service_config(name, payload.config)
-    if result.get("status") == "error":
-        raise HTTPException(status_code=400, detail=result.get("message"))
-    return result
-
 app.include_router(services_router)
-
-@app.websocket("/ws/services/status")
-async def websocket_services_status(websocket: WebSocket):
-    await websocket.accept()
-    try:
-        while True:
-            status_data = orchestrator.get_services_status()
-            await websocket.send_json({
-                "type": "services_status",
-                "data": status_data
-            })
-            await asyncio.sleep(1.5)
-    except WebSocketDisconnect:
-        logger.debug("Services status WebSocket disconnected")
-    except Exception as e:
-        logger.error(f"Services status WebSocket error: {e}")
-
-# Add this helper function to handle JSON serialization
-def json_serial(obj):
-    """JSON serializer for objects not serializable by default json code"""
-    if isinstance(obj, (datetime, dt.date)):
-        return obj.isoformat()
-    if hasattr(obj, 'dict'):
-        return obj.dict()
-    raise TypeError(f"Type {type(obj)} not serializable")
+app.include_router(services_ws_router)

--- a/services/serve/routers/__init__.py
+++ b/services/serve/routers/__init__.py
@@ -1,0 +1,1 @@
+# routers package

--- a/services/serve/routers/market.py
+++ b/services/serve/routers/market.py
@@ -1,0 +1,233 @@
+import json
+import logging
+import asyncio
+import datetime as dt
+from datetime import datetime
+from typing import List
+import pytz
+
+from fastapi import APIRouter, HTTPException, Query, WebSocket, Request
+from starlette.websockets import WebSocketDisconnect
+from websockets.exceptions import ConnectionClosed
+
+from ..models import (
+    PaginatedResponse,
+    LatestPriceData,
+    TransformedOrderBookData,
+    TransformedOrderBookDataPoint,
+    CandlestickData
+)
+from ..data import (
+    get_latest_price,
+    get_latest_transformed_order_book_point,
+    get_transformed_order_book,
+    get_historic_price,
+    get_candlestick_data
+)
+from ..websocket import websocket_manager
+
+logger = logging.getLogger("fastapi_server")
+
+router = APIRouter()
+
+def json_serial(obj):
+    """JSON serializer for objects not serializable by default json code"""
+    if isinstance(obj, (datetime, dt.date)):
+        return obj.isoformat()
+    if hasattr(obj, 'dict'):
+        return obj.dict()
+    raise TypeError(f"Type {type(obj)} not serializable")
+
+
+@router.websocket("/ws/price/{token}")
+async def websocket_price(websocket: WebSocket, token: str):
+    await websocket_manager.connect(websocket, 'price')
+    
+    async def send_message(message: dict):
+        try:
+            await websocket.send_text(json.dumps(message, default=json_serial))
+            return True
+        except (WebSocketDisconnect, RuntimeError) as e:
+            logger.debug(f"Failed to send message (connection closed): {e}")
+            return False
+        except Exception as e:
+            logger.error(f"Error sending message: {e}")
+            return False
+    
+    try:
+        # Send current price immediately on connection
+        price_data = await get_latest_price(websocket.app, token)
+        if price_data and not await send_message({
+            'type': 'price_update',
+            'token': token,
+            'data': price_data.dict() if hasattr(price_data, 'dict') else price_data
+        }):
+            return  # Stop if we couldn't send the initial message
+        
+        # Keep connection alive with heartbeats
+        while True:
+            await asyncio.sleep(30)  # Send heartbeat every 30 seconds
+            if not await send_message({'type': 'ping'}):
+                break  # Stop if we can't send a heartbeat
+                
+    except WebSocketDisconnect:
+        logger.info(f"WebSocket disconnected for token {token}")
+    except Exception as e:
+        logger.error(f"WebSocket error for token {token}: {e}")
+    finally:
+        await websocket_manager.disconnect(websocket, 'price')
+
+
+@router.websocket("/ws/order_book/{token}")
+async def websocket_order_book(websocket: WebSocket, token: str):
+    await websocket_manager.connect(websocket, 'order_book')
+    
+    async def send_message(message: dict):
+        try:
+            await websocket.send_text(json.dumps(message, default=json_serial))
+            return True
+        except (WebSocketDisconnect, RuntimeError) as e:
+            logger.debug(f"Failed to send order book message (connection closed): {e}")
+            return False
+        except Exception as e:
+            logger.error(f"Error sending order book message: {e}")
+            return False
+    
+    try:
+        # Send current order book immediately on connection
+        order_book = await get_latest_transformed_order_book_point(websocket.app, token)
+        if order_book and not await send_message({
+            'type': 'order_book_update',
+            'token': token,
+            'data': order_book.dict()
+        }):
+            return  # Stop if we couldn't send the initial message
+        
+        # Keep connection alive with heartbeats
+        while True:
+            await asyncio.sleep(30)  # Send heartbeat every 30 seconds
+            if not await send_message({'type': 'ping'}):
+                break  # Stop if we can't send a heartbeat
+                
+    except WebSocketDisconnect:
+        logger.info(f"Order book WebSocket disconnected for token {token}")
+    except Exception as e:
+        logger.error(f"Order book WebSocket error for token {token}: {e}")
+    finally:
+        await websocket_manager.disconnect(websocket, 'order_book')
+
+
+# --- REST API Endpoints ---
+@router.get("/historic/price/{token}", response_model=PaginatedResponse)
+async def read_historic_price(
+    request: Request,
+    token: str,
+    start: datetime = Query(..., description="Start time (ISO 8601 format)"),
+    end: datetime = Query(..., description="End time (ISO 8601 format)"),
+    page: int = Query(1, ge=1, description="Page number (1-based)"),
+    page_size: int = Query(1000, ge=1, le=10000, description="Number of items per page (max 10000)")
+):
+    """
+    Get paginated historic price data for a token within a time range.
+    """
+    try:
+        # Convert start and end to UTC
+        start_utc = start.astimezone(pytz.utc)
+        end_utc = end.astimezone(pytz.utc)
+
+        if end_utc <= start_utc:
+            raise HTTPException(status_code=400, detail="End time must be after start time")
+
+        # Fetch paginated historic price data
+        price_data, total_count = await get_historic_price(
+            request.app,
+            token=token,
+            start_time=start_utc,
+            end_time=end_utc,
+            page=page,
+            page_size=page_size
+        )
+        
+        # Calculate pagination metadata
+        total_pages = (total_count + page_size - 1) // page_size if page_size > 0 else 1
+        has_next = page < total_pages
+        has_previous = page > 1
+        
+        return {
+            "data": price_data,
+            "total": total_count,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": total_pages,
+            "has_next": has_next,
+            "has_previous": has_previous
+        }
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching historic price data for {token}: {e}")
+        raise HTTPException(status_code=500, detail=f"Error fetching historic price data: {e}")
+
+
+@router.get("/candlestick/{token}", response_model=List[CandlestickData])
+async def read_candlestick(
+    request: Request,
+    token: str,
+    start: datetime = Query(..., description="Start time (ISO 8601 format)"),
+    end: datetime = Query(..., description="End time (ISO 8601 format)"),
+    granularity: int = Query(..., description="Candlestick interval in seconds"),
+    include_book: bool = Query(False, description="Include order book data in response")
+):
+    """
+    Retrieve candlestick data for a specific symbol within a given time range and granularity.
+    """
+    try:
+        # Convert start and end to UTC
+        start_utc = start.astimezone(pytz.utc)
+        end_utc = end.astimezone(pytz.utc)
+
+        if end_utc <= start_utc:
+            raise HTTPException(status_code=400, detail="End time must be greater than start time.")
+        if granularity <= 0:
+            raise HTTPException(status_code=400, detail="Granularity must be a positive integer.")
+        data = await get_candlestick_data(request.app, token, start_utc, end_utc, granularity, include_book)
+
+        if not data:
+             raise HTTPException(status_code=404, detail=f"No data found for {token} between {start_utc} and {end_utc}")
+        return data
+    except ValueError as ve:
+        raise HTTPException(status_code=400, detail=f"Invalid date format: {ve}")
+
+
+@router.get("/latest_price/{token}", response_model=LatestPriceData)
+async def read_latest_price(request: Request, token: str):
+    """
+    Retrieve the latest index price for a specific token.
+    """
+    price_data = await get_latest_price(request.app, token)
+    if price_data is None:
+        raise HTTPException(status_code=404, detail=f"No data found for token {token}")
+    return price_data
+
+
+@router.get("/transformed_order_book/{token}", response_model=TransformedOrderBookData)
+async def read_transformed_order_book(request: Request, token: str):
+    """
+    Retrieve the transformed order book for a specific token.
+    """
+    transformed_order_book = await get_transformed_order_book(request.app, token)
+    if transformed_order_book is None:
+        raise HTTPException(status_code=404, detail=f"No data found for token {token}")
+    return transformed_order_book
+
+
+@router.get("/latest_transformed_order_book_point/{token}", response_model=TransformedOrderBookDataPoint)
+async def read_latest_transformed_order_book_point(request: Request, token: str):
+    """
+    Retrieve the latest transformed order book point for a specific token.
+    """
+    transformed_order_book_point = await get_latest_transformed_order_book_point(request.app, token)
+    if transformed_order_book_point is None:
+        raise HTTPException(status_code=404, detail=f"No data found for token {token}")
+    return transformed_order_book_point

--- a/services/serve/routers/retrieval.py
+++ b/services/serve/routers/retrieval.py
@@ -1,0 +1,24 @@
+import logging
+import os
+import httpx
+from fastapi import APIRouter, HTTPException
+
+logger = logging.getLogger("fastapi_server")
+
+router = APIRouter(prefix="/retrieval")
+
+@router.get("/forecast")
+async def forecast(symbol: str = "BTC", k: int = 5):
+    """Proxy to retrieval service with robust timeout and error handling."""
+    retrieval_url = os.getenv("RETRIEVAL_SERVICE_URL", "http://localhost:8000")
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(f"{retrieval_url}/forecast?symbol={symbol}&k={k}")
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError as e:
+        logger.error(f"Error proxying to retrieval service: {e}")
+        raise HTTPException(
+            status_code=502,
+            detail=f"Retrieval service error: {str(e)}"
+        )

--- a/services/serve/routers/services.py
+++ b/services/serve/routers/services.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+from typing import Dict
+from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
+
+from cryptotrading.util.orchestrator import ServiceOrchestrator
+
+logger = logging.getLogger("fastapi_server")
+
+router = APIRouter(prefix="/services")
+ws_router = APIRouter(prefix="/ws/services")
+
+orchestrator = ServiceOrchestrator()
+
+class ConfigUpdatePayload(BaseModel):
+    config: Dict[str, str]
+
+@router.get("")
+async def get_services():
+    return orchestrator.get_services_status()
+
+@router.post("/{name}/start")
+async def start_service_endpoint(name: str):
+    result = orchestrator.start_service(name)
+    if result.get("status") == "error":
+        raise HTTPException(status_code=400, detail=result.get("message"))
+    return result
+
+@router.post("/{name}/stop")
+async def stop_service_endpoint(name: str):
+    result = orchestrator.stop_service(name)
+    if result.get("status") == "error":
+        raise HTTPException(status_code=400, detail=result.get("message"))
+    return result
+
+@router.post("/{name}/restart")
+async def restart_service_endpoint(name: str):
+    result = orchestrator.restart_service(name)
+    if result.get("status") == "error":
+        raise HTTPException(status_code=400, detail=result.get("message"))
+    return result
+
+@router.get("/{name}/logs")
+async def get_service_logs_endpoint(name: str, limit: int = 100):
+    logs = orchestrator.get_service_logs(name, limit)
+    return {"logs": logs}
+
+@router.post("/{name}/config")
+async def update_service_config_endpoint(name: str, payload: ConfigUpdatePayload):
+    result = orchestrator.update_service_config(name, payload.config)
+    if result.get("status") == "error":
+        raise HTTPException(status_code=400, detail=result.get("message"))
+    return result
+
+@ws_router.websocket("/status")
+async def websocket_services_status(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            status_data = orchestrator.get_services_status()
+            await websocket.send_json({
+                "type": "services_status",
+                "data": status_data
+            })
+            await asyncio.sleep(1.5)
+    except WebSocketDisconnect:
+        logger.debug("Services status WebSocket disconnected")
+    except Exception as e:
+        logger.error(f"Services status WebSocket error: {e}")

--- a/services/serve/websocket.py
+++ b/services/serve/websocket.py
@@ -3,6 +3,13 @@ import asyncio
 from fastapi import WebSocket
 from typing import Dict, Set
 import logging
+from starlette.websockets import WebSocketDisconnect
+from websockets.exceptions import ConnectionClosed
+
+try:
+    from uvicorn.protocols.utils import ClientDisconnected
+except ImportError:
+    ClientDisconnected = None
 
 logger = logging.getLogger("fastapi_server")
 
@@ -20,26 +27,36 @@ class ConnectionManager:
         async with self.lock:
             self.active_connections[channel].add(websocket)
 
-    def disconnect(self, websocket: WebSocket, channel: str):
-        if websocket in self.active_connections[channel]:
-            self.active_connections[channel].remove(websocket)
+    async def disconnect(self, websocket: WebSocket, channel: str):
+        async with self.lock:
+            if websocket in self.active_connections[channel]:
+                self.active_connections[channel].remove(websocket)
 
     async def broadcast(self, message: str, channel: str):
         if channel not in self.active_connections:
             return
             
         disconnected = set()
-        for connection in self.active_connections[channel]:
+        # Use list to avoid RuntimeError if active_connections is modified during iteration
+        for connection in list(self.active_connections[channel]):
             try:
                 await connection.send_text(message)
+            except (WebSocketDisconnect, ConnectionClosed) as e:
+                logger.debug(f"WebSocket client disconnected on {channel} channel: {e}")
+                disconnected.add(connection)
             except Exception as e:
-                # get stack trace
-                import traceback
-                logger.warning(traceback.format_exc())
-                logger.warning(f"Error sending to WebSocket: {e}")
+                if ClientDisconnected and isinstance(e, ClientDisconnected):
+                    logger.debug(f"WebSocket client disconnected on {channel} channel: {e}")
+                else:
+                    import traceback
+                    logger.warning(f"Error sending to WebSocket on {channel} channel: {e}")
+                    logger.warning(traceback.format_exc())
                 disconnected.add(connection)
         
         if disconnected:
             async with self.lock:
                 self.active_connections[channel] -= disconnected
+
+
+websocket_manager = ConnectionManager()
 

--- a/src/cryptotrading/predict/train.py
+++ b/src/cryptotrading/predict/train.py
@@ -18,9 +18,9 @@ from torch.utils.data import DataLoader
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.model_selection import train_test_split
 import matplotlib.pyplot as plt
-from models import get_model
-from dotdict import dotdict
-from data import TimeSeriesDataset
+from cryptotrading.predict.models import get_model
+from cryptotrading.predict.utils.tools import dotdict
+from cryptotrading.predict.data import TimeSeriesDataset
 
 # Set random seeds for reproducibility
 torch.manual_seed(42)

--- a/src/cryptotrading/sentiment/analyzer.py
+++ b/src/cryptotrading/sentiment/analyzer.py
@@ -26,16 +26,11 @@ import logging
 import datetime as dt
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
-from dataclasses import dataclass, asdict
 
 # External dependencies
 import twikit
-import pymongo
 from textblob import TextBlob
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
-import pandas as pd
-from dotenv import load_dotenv
-
 from pydantic import BaseModel, field_validator
 
 from cryptotrading.data.models import TweetDataPoint, TweetSentiment


### PR DESCRIPTION
## Summary
Refactored the monolithic API gateway server in `services/serve/app.py` into separate, modular `APIRouter` submodules under `services/serve/routers/`. This improves codebase modularity, readability, and isolates concerns for market feeds, pattern retrievals, and orchestration management.

## Changes
- **Modularized FastAPI Endpoints**: Extracted endpoints from `app.py` into logical sub-modules:
  - `routers/market.py`: REST & WebSockets for price streams, order books, and candlestick charting.
  - `routers/retrieval.py`: REST query proxying to the standalone forecast service.
  - `routers/services.py`: REST and WebSocket update connections for service management.
- **Unified Connection Management**: Instantiated a global shared `websocket_manager` ConnectionManager in `services/serve/websocket.py` so that background change watchers in `app.py` and active WebSocket routes in `market.py` target the exact same connection pool.
- **Decoupled State**: Shuffled all database and adapter dependencies directly into request/websocket contexts using `request.app` and `websocket.app`.
- **Documentation**: Populated `services/serve/README.md` with architecture details and updated active context and progress logs.

## Testing
- [x] Tests pass locally (`pytest tests/test_orchestrator.py tests/test_order_book_analytics.py tests/test_forecaster.py`)
- [x] Docs updated

## Related Issues
Closes #7 (Split up the serve app.py file into different files for different APIRouter prefix)
