### PR TITLE
feat(frontend): chunk candlestick data queries to prevent timeouts

### DIFF
--- a/.agent/core/activeContext.md
+++ b/.agent/core/activeContext.md
@@ -1,29 +1,29 @@
-# Active Context: Optimize Candlestick & Price Queries to Prevent Timeouts
+# Active Context: Frontend Candlestick Query Chunking & Optimization
 
 ## Quick Reference
-- **Feature**: Optimize Candlestick & Price Queries
+- **Feature**: Frontend Candlestick Query Chunking
 - **Status**: Completed & Verified ✅
 
 ## Executive Summary
-Resolved candlestick chart loading timeouts (`QueryCanceledError`) by recovering host disk space (freeing ~13.2 GB of space to boot up TimescaleDB) and rewriting database query interfaces to bypass slow JSONB metadata filtering and prefix-LIKE matches. Introduced a SkipScan-based `resolve_matching_symbols` helper to resolve tokens to symbol lists and query with parallel index scans (`symbol = ANY($1)`).
+Optimized the retrieval of historical candlestick data on the frontend to avoid large queries that can lead to database timeouts and payload transmission issues. Developed a transparent range division algorithm directly in `api.js` that splits query durations into smaller granularity-based sub-ranges, queries them in small concurrent batches, gracefully handles empty chunk responses, and deduplicates and sorts the final consolidated data set.
 
 ## Architecture Overview
-Queries on the `price_data` table (9.5+ million rows) now run in under 200 ms. The SkipScan helper queries unique symbols in under 1 ms using TimescaleDB's metadata chunk indexes. All service endpoints (`serve`, `retrieval`, `analysis`) now execute highly efficient parallel B-tree index scans on `idx_price_data_symbol_time`.
+The frontend `getCandlestickData` function acts as a wrapper that:
+1. Calculates chunk intervals based on a target size of 1000 data points per query (`chunkDurationMs = 1000 * granularity * 1000`).
+2. Iterates over time ranges and requests chunks.
+3. Limits concurrent request volume using a simple batch execution array (`CONCURRENCY_LIMIT = 3`).
+4. Catches 404 response errors dynamically on missing ranges to return empty results rather than crashing the request.
+5. Deduplicates by timestamp and sorts chronologically before returning the result array.
 
 ## Tech Stack for This Feature
-- **PostgreSQL + TimescaleDB**: Query optimizations and hypertable indexing
-- **asyncpg**: Async database driver and connection pool management
-- **Docker Compose**: Service container orchestration and system resource cleaning
+- **React + Vite**: UI Rendering
+- **Axios**: HTTP query execution & error handling
+- **date-fns**: Time parsing and formatting
 
 ## Key Files Created/Modified
-- [postgres.py](file:///home/miles/Development/notebooks/CryptoTrading/src/cryptotrading/data/postgres.py): Added `resolve_matching_symbols` SkipScan query helper.
-- [price.py](file:///home/miles/Development/notebooks/CryptoTrading/src/cryptotrading/data/price.py): Optimized `get_price_data`, `get_price_data_count`, `get_latest_price`, and `get_candlestick_data`.
-- [book.py](file:///home/miles/Development/notebooks/CryptoTrading/src/cryptotrading/data/book.py): Optimized `get_orderbook_data`, `get_latest_transformed_order_book_point`, and `get_transformed_order_book`.
-- [price.py](file:///home/miles/Development/notebooks/CryptoTrading/src/cryptotrading/analysis/price.py): Optimized raw exchange price analysis retrieval.
-- [retrieval.py](file:///home/miles/Development/notebooks/CryptoTrading/services/serve/routers/retrieval.py): Optimized JEPA market regime calculation queries.
+- [api.js](file:///home/miles/Development/notebooks/CryptoTrading/frontend/src/services/api.js): Implemented transparent chunking, batch concurrency, and deduplication logic.
 
 ## Verification & Validation
-- **Automated Tests**: Executed database query tests and pytest suite:
-  - `PYTHONPATH=src uv run python test_db.py` -> **Passed**
-  - `uv run pytest tests/` -> **26 Passed**
-- **Manual Verification**: Curled the `candlestick` endpoint (`http://localhost:8362/candlestick/BTC`) and verified immediate returns (under ~200 ms) without timeouts.
+- **Automated Verification**: Ran a Node.js simulator test ([test_chunking.js](file:///home/miles/.gemini/antigravity-ide/brain/891add4f-aac1-4522-9c11-e282e89f7a1f/scratch/test_chunking.js)) verifying single-chunk, multi-chunk, parallel batching, sorting, and deduplication correctness.
+- **Production Asset Build**: Executed `npm run build` inside `frontend/` successfully without compilation warnings/errors.
+

--- a/.agent/core/progress.md
+++ b/.agent/core/progress.md
@@ -102,6 +102,12 @@
 - [x] Resolve SQL query timeouts on the 9.5M-row `price_data` table by replacing slow JSONB filters and pattern-LIKE matches with SkipScan-based `resolve_matching_symbols` and indexed `symbol = ANY($1)` scans.
 - [x] Verify query performance and correctness via tests and endpoints, restoring candlestick rendering in under 200 ms.
 
+### Phase 16: Frontend Candlestick Query Chunking (Completed ✅)
+- [x] Chunk up large historical candlestick fetches transparently inside `getCandlestickData` using dynamic range division based on query granularity.
+- [x] Implement a concurrent batching queue (with limit of 3 concurrent requests) to execute chunk queries in parallel safely.
+- [x] Deduplicate overlapping data points by timestamp and sort chronologically.
+- [x] Handle 404 response cases gracefully by treating missing data chunks as empty lists instead of failing the entire query.
+
 ## Sprint Progress
  
 - [x] Remove mock results and simulated data states from the frontend.
@@ -109,3 +115,4 @@
 - [x] Align CandlestickChart and OrderBookPanel components with the global dark theme.
 - [x] Rework Order Book snapshot panel into a cumulative depth chart visualizer.
 - [x] Polish up the embed service, centralize pgvector database storage, and write comprehensive tests.
+- [x] Implement transparent historical candlestick query chunking on the frontend.

--- a/frontend/src/components/CandlestickChart.jsx
+++ b/frontend/src/components/CandlestickChart.jsx
@@ -191,8 +191,8 @@ const CandlestickChart = ({ token }) => {
     };
 
     // Only set up the WebSocket connection after the component is mounted
-    // and we have a valid token
-    if (token) {
+    // and we have a valid token and historical data is loaded
+    if (token && historicalDataLoaded) {
       connectWebSocket();
 
       // Set up the price update handler
@@ -562,6 +562,9 @@ const CandlestickChart = ({ token }) => {
               onChange={handleGranularityChange}
               className="bg-slate-950 border border-slate-800 rounded-lg px-3 py-1.5 text-xs text-slate-300 focus:outline-none focus:border-slate-700"
             >
+              <option value={5}>5 Seconds</option>
+              <option value={15}>15 Seconds</option>
+              <option value={30}>30 Seconds</option>
               <option value={60}>1 Minute</option>
               <option value={300}>5 Minutes</option>
               <option value={900}>15 Minutes</option>
@@ -572,11 +575,10 @@ const CandlestickChart = ({ token }) => {
           <div className="flex items-end self-end h-[32px] mt-4 sm:mt-0">
             <button
               onClick={toggleLiveUpdates}
-              className={`px-4 py-1.5 rounded-lg text-white text-xs font-semibold border transition-all ${
-                isLiveUpdating 
-                  ? 'bg-rose-900/40 text-rose-300 border-rose-800/50 hover:bg-rose-900/50' 
-                  : 'bg-emerald-900/40 text-emerald-300 border-emerald-800/50 hover:bg-emerald-900/50'
-              }`}
+              className={`px-4 py-1.5 rounded-lg text-white text-xs font-semibold border transition-all ${isLiveUpdating
+                ? 'bg-rose-900/40 text-rose-300 border-rose-800/50 hover:bg-rose-900/50'
+                : 'bg-emerald-900/40 text-emerald-300 border-emerald-800/50 hover:bg-emerald-900/50'
+                }`}
             >
               {isLiveUpdating ? 'Pause Live Updates' : 'Enable Live Updates'}
             </button>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -425,9 +425,15 @@ export const getCandlestickData = async (token, start, end, granularity) => {
       return [];
     }
 
+    let safeGranularity = granularity;
+    if (!safeGranularity || safeGranularity <= 0) {
+      console.warn(`Invalid granularity: ${safeGranularity}, defaulting to 60 seconds`);
+      safeGranularity = 60;
+    }
+
     // Limit maximum data points per chunk to 1000
     const MAX_POINTS_PER_QUERY = 1000;
-    const chunkDurationMs = MAX_POINTS_PER_QUERY * granularity * 1000;
+    const chunkDurationMs = MAX_POINTS_PER_QUERY * safeGranularity * 1000;
 
     // Generate chunks
     const chunks = [];
@@ -460,7 +466,7 @@ export const getCandlestickData = async (token, start, end, granularity) => {
             params: {
               start: formattedStart,
               end: formattedEnd,
-              granularity,
+              granularity: safeGranularity,
               include_book: true
             },
           });

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -417,36 +417,85 @@ export const webSocketService = new WebSocketService();
 export const getCandlestickData = async (token, start, end, granularity) => {
   console.log('getCandlestickData called with:', { token, start, end, granularity });
   try {
-    const formattedStart = formatISO(start);  // Format dates for the API
-    const formattedEnd = formatISO(end);
-    console.log('Formatted dates:', { formattedStart, formattedEnd });
-    
-    console.log('Making API request to:', `/candlestick/${token}`, {
-      params: { start: formattedStart, end: formattedEnd, granularity, include_book: true }
-    });
-    
-    const response = await api.get(`/candlestick/${token}`, {
-      params: {
-        start: formattedStart,
-        end: formattedEnd,
-        granularity,
-        include_book: true
-      },
-    });
-    
-    console.log('API response received:', {
-      status: response.status,
-      statusText: response.statusText,
-      dataLength: response.data ? response.data.length : 0,
-      dataSample: response.data ? response.data.slice(0, 2) : null
-    });
-    
-    if (!response.data) {
-      console.warn('No data in API response');
+    const startTime = new Date(start).getTime();
+    const endTime = new Date(end).getTime();
+
+    if (startTime >= endTime) {
+      console.warn('Start time is greater than or equal to end time');
       return [];
     }
-    
-    return response.data;
+
+    // Limit maximum data points per chunk to 1000
+    const MAX_POINTS_PER_QUERY = 1000;
+    const chunkDurationMs = MAX_POINTS_PER_QUERY * granularity * 1000;
+
+    // Generate chunks
+    const chunks = [];
+    let currentStart = startTime;
+    while (currentStart < endTime) {
+      const currentEnd = Math.min(currentStart + chunkDurationMs, endTime);
+      chunks.push({
+        start: new Date(currentStart),
+        end: new Date(currentEnd)
+      });
+      currentStart = currentEnd;
+    }
+
+    console.log(`Splitting query into ${chunks.length} chunk(s) based on granularity ${granularity}s`);
+
+    // Concurrency limit for chunk queries
+    const CONCURRENCY_LIMIT = 3;
+    const allResults = [];
+
+    for (let i = 0; i < chunks.length; i += CONCURRENCY_LIMIT) {
+      const batch = chunks.slice(i, i + CONCURRENCY_LIMIT);
+      console.log(`Executing batch ${Math.floor(i / CONCURRENCY_LIMIT) + 1}/${Math.ceil(chunks.length / CONCURRENCY_LIMIT)} with ${batch.length} queries`);
+
+      const batchPromises = batch.map(async (chunk) => {
+        const formattedStart = formatISO(chunk.start);
+        const formattedEnd = formatISO(chunk.end);
+
+        try {
+          const response = await api.get(`/candlestick/${token}`, {
+            params: {
+              start: formattedStart,
+              end: formattedEnd,
+              granularity,
+              include_book: true
+            },
+          });
+          return response.data || [];
+        } catch (error) {
+          if (error.response && error.response.status === 404) {
+            console.warn(`No data found for chunk: ${formattedStart} to ${formattedEnd}`);
+            return [];
+          }
+          console.error(`Error fetching chunk start=${formattedStart} end=${formattedEnd}:`, error);
+          throw error;
+        }
+      });
+
+      const batchResults = await Promise.all(batchPromises);
+      for (const data of batchResults) {
+        allResults.push(...data);
+      }
+    }
+
+    // Deduplicate by timestamp and sort chronologically
+    const uniqueDataMap = new Map();
+    for (const item of allResults) {
+      if (item && item.timestamp) {
+        const ts = new Date(item.timestamp).getTime();
+        uniqueDataMap.set(ts, item);
+      }
+    }
+
+    const sortedData = Array.from(uniqueDataMap.values()).sort((a, b) => {
+      return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+    });
+
+    console.log(`Total retrieved candlestick points: ${sortedData.length}`);
+    return sortedData;
   } catch (error) {
     console.error("Error fetching candlestick data:", error);
     if (error.response) {

--- a/services/embed/server.py
+++ b/services/embed/server.py
@@ -112,6 +112,38 @@ app.add_middleware(
 state = AppState()
 
 
+def _process_symbol_sync(sym, prices, timestamps, window_size, encoder, device):
+    """Synchronous CPU-bound processing to compute oracle actions and extract setups."""
+    oracle = LeveragedDPOracle(max_leverage=20.0, transaction_cost=0.001)
+    actions, leverages = oracle.compute_oracle_actions(prices)
+    setups = extract_trade_setups(
+        prices=prices,
+        timestamps=timestamps,
+        oracle_actions=actions,
+        oracle_leverages=leverages,
+        window_size=window_size
+    )
+    if not setups:
+        return [], None
+
+    # Generate embeddings
+    encoder.eval()
+    embeddings = []
+    batch_size = 256
+    for i in range(0, len(setups), batch_size):
+        batch = setups[i:i + batch_size]
+        windows = np.stack([s.price_window for s in batch])
+        with torch.no_grad():
+            x = torch.from_numpy(windows).float().to(device)
+            emb = encoder(x).cpu().numpy()
+        embeddings.append(emb)
+
+    if embeddings:
+        embeddings = np.vstack(embeddings)
+
+    return setups, embeddings
+
+
 async def auto_populate_db():
     """Background task to wait for bootstrapped price data and automatically populate trade setups vector store."""
     logger.info("Starting auto-population background task...")
@@ -123,6 +155,8 @@ async def auto_populate_db():
     
     # Give the connection/schema initialization a moment
     await asyncio.sleep(2)
+    
+    from cryptotrading.data.postgres import init_pool
     
     while retries < max_retries:
         if state.store is None:
@@ -143,12 +177,11 @@ async def auto_populate_db():
             logger.info(f"Vector store already contains {total_setups} setups. Skipping auto-population.")
             return
             
-        # Check if price_data has entries
+        # Check if price_data has entries using connection pool
         try:
-            postgres_uri = os.getenv("POSTGRES_URI", "postgresql://postgres:postgres@timescaledb:5432/crypto_trading")
-            conn = await asyncpg.connect(dsn=postgres_uri)
-            count = await conn.fetchval("SELECT COUNT(*) FROM price_data")
-            await conn.close()
+            pool = state.store.pool if (isinstance(state.store, TradeEmbeddingDB) and state.store.pool is not None) else await init_pool()
+            async with pool.acquire() as conn:
+                count = await conn.fetchval("SELECT COUNT(*) FROM price_data")
                 
             if count and count >= 120:  # Need at least some window of data
                 logger.info(f"Found {count} price records in database. Starting embedding extraction...")
@@ -166,130 +199,124 @@ async def auto_populate_db():
         
     # Query price data
     try:
-        postgres_uri = os.getenv("POSTGRES_URI", "postgresql://postgres:postgres@timescaledb:5432/crypto_trading")
-        conn = await asyncpg.connect(dsn=postgres_uri)
-        rows = await conn.fetch("SELECT symbol, time, close FROM price_data ORDER BY symbol, time ASC")
-        await conn.close()
-            
-        if not rows:
-            logger.warning("No price data fetched.")
+        pool = state.store.pool if (isinstance(state.store, TradeEmbeddingDB) and state.store.pool is not None) else await init_pool()
+        
+        # Get unique symbols
+        async with pool.acquire() as conn:
+            symbols_rows = await conn.fetch("SELECT DISTINCT symbol FROM price_data")
+        
+        symbols = [r['symbol'] for r in symbols_rows]
+        if not symbols:
+            logger.warning("No symbols found in price data.")
             return
             
-        # Group by symbol
-        data_by_symbol = {}
-        for r in rows:
-            sym = r['symbol']
-            if sym not in data_by_symbol:
-                data_by_symbol[sym] = {'prices': [], 'timestamps': []}
-            data_by_symbol[sym]['prices'].append(float(r['close']))
-            data_by_symbol[sym]['timestamps'].append(r['time'].timestamp())
-            
-        oracle = LeveragedDPOracle(max_leverage=20.0, transaction_cost=0.001)
-        
         total_extracted = 0
         total_inserted = 0
         
-        for sym, d in data_by_symbol.items():
-            prices = np.array(d['prices'], dtype=np.float64)
-            timestamps = np.array(d['timestamps'], dtype=np.float64)
+        for sym in symbols:
+            # Query data per symbol to avoid memory overload
+            async with pool.acquire() as conn:
+                rows = await conn.fetch("SELECT time, close FROM price_data WHERE symbol = $1 ORDER BY time ASC", sym)
+                
+            if not rows:
+                continue
+                
+            prices_list = []
+            timestamps_list = []
+            for r in rows:
+                prices_list.append(float(r['close']))
+                timestamps_list.append(r['time'].timestamp())
+                
+            prices = np.array(prices_list, dtype=np.float64)
+            timestamps = np.array(timestamps_list, dtype=np.float64)
             
             if len(prices) < state.window_size:
                 logger.warning(f"Insufficient price data for {sym} to extract setups (need {state.window_size}, got {len(prices)})")
                 continue
                 
             logger.info(f"Extracting setups for {sym} ({len(prices)} prices)...")
-            actions, leverages = oracle.compute_oracle_actions(prices)
-            setups = extract_trade_setups(
-                prices=prices,
-                timestamps=timestamps,
-                oracle_actions=actions,
-                oracle_leverages=leverages,
-                window_size=state.window_size
+            
+            # Offload heavy CPU calculations to worker thread to keep the event loop responsive
+            device = next(state.encoder.parameters()).device
+            setups, embeddings = await asyncio.to_thread(
+                _process_symbol_sync,
+                sym,
+                prices,
+                timestamps,
+                state.window_size,
+                state.encoder,
+                device
             )
             
-            logger.info(f"Extracted {len(setups)} setups for {sym}")
-            if not setups:
+            if not setups or embeddings is None:
                 continue
                 
+            logger.info(f"Extracted {len(setups)} setups for {sym}")
             total_extracted += len(setups)
             
-            # Generate embeddings
-            state.encoder.eval()
-            device = next(state.encoder.parameters()).device
-            
-            embeddings = []
-            batch_size = 256
-            for i in range(0, len(setups), batch_size):
-                batch = setups[i:i + batch_size]
-                windows = np.stack([s.price_window for s in batch])
-                with torch.no_grad():
-                    x = torch.from_numpy(windows).float().to(device)
-                    emb = state.encoder(x).cpu().numpy()
-                embeddings.append(emb)
-            
-            if embeddings:
-                embeddings = np.vstack(embeddings)
+            # Convert to StoredTradeSetup objects
+            stored_setups = []
+            for idx, setup in enumerate(setups):
+                start_idx = max(0, setup.entry_idx - state.window_size)
+                end_idx = setup.entry_idx
+                raw_prices = prices[start_idx:end_idx]
+                entry_price = float(prices[setup.entry_idx])
+                exit_idx = min(setup.entry_idx + setup.hold_duration, len(prices) - 1)
+                exit_price = float(prices[exit_idx])
                 
-                # Convert to StoredTradeSetup objects
-                stored_setups = []
-                for idx, setup in enumerate(setups):
-                    start_idx = max(0, setup.entry_idx - state.window_size)
-                    end_idx = setup.entry_idx
-                    raw_prices = prices[start_idx:end_idx]
-                    entry_price = float(prices[setup.entry_idx])
-                    exit_idx = min(setup.entry_idx + setup.hold_duration, len(prices) - 1)
-                    exit_price = float(prices[exit_idx])
+                target_len = state.window_size
+                if len(raw_prices) < target_len:
+                    raw_prices = np.pad(raw_prices, (target_len - len(raw_prices), 0), mode='edge')
+                elif len(raw_prices) > target_len:
+                    raw_prices = raw_prices[-target_len:]
                     
-                    target_len = state.window_size
-                    if len(raw_prices) < target_len:
-                        raw_prices = np.pad(raw_prices, (target_len - len(raw_prices), 0), mode='edge')
-                    elif len(raw_prices) > target_len:
-                        raw_prices = raw_prices[-target_len:]
-                        
-                    stored = StoredTradeSetup(
-                        id=None,
-                        embedding=embeddings[idx],
-                        direction=setup.direction,
-                        profit_pct=setup.profit_pct,
-                        leverage=setup.leverage,
-                        hold_duration=setup.hold_duration,
-                        entry_timestamp=float(timestamps[setup.entry_idx]),
-                        entry_price=entry_price,
-                        exit_price=exit_price,
-                        symbol=sym,
-                        timeframe='1m',
-                        window_size=state.window_size,
-                        price_window=raw_prices
+                stored = StoredTradeSetup(
+                    id=None,
+                    embedding=embeddings[idx],
+                    direction=setup.direction,
+                    profit_pct=setup.profit_pct,
+                    leverage=setup.leverage,
+                    hold_duration=setup.hold_duration,
+                    entry_timestamp=float(timestamps[setup.entry_idx]),
+                    entry_price=entry_price,
+                    exit_price=exit_price,
+                    symbol=sym,
+                    timeframe='1m',
+                    window_size=state.window_size,
+                    price_window=raw_prices
+                )
+                stored_setups.append(stored)
+                
+            # Insert into store
+            if isinstance(state.store, TradeEmbeddingDB):
+                ids = await state.store.insert_batch(stored_setups)
+                total_inserted += len(ids)
+            else:
+                price_windows_padded = np.array([s.price_window for s in stored_setups])
+                from database.numpy_store import StoredTradeSetup as NumpyStoredTradeSetup
+                numpy_stored_setups = []
+                for s in stored_setups:
+                    n_s = NumpyStoredTradeSetup(
+                        id=0,
+                        direction=s.direction,
+                        profit_pct=s.profit_pct,
+                        leverage=s.leverage,
+                        hold_duration=s.hold_duration,
+                        entry_timestamp=s.entry_timestamp,
+                        entry_price=s.entry_price,
+                        exit_price=s.exit_price,
+                        symbol=s.symbol,
+                        timeframe=s.timeframe,
+                        window_size=s.window_size
                     )
-                    stored_setups.append(stored)
-                    
-                # Insert into store
-                if isinstance(state.store, TradeEmbeddingDB):
-                    ids = await state.store.insert_batch(stored_setups)
-                    total_inserted += len(ids)
-                else:
-                    price_windows_padded = np.array([s.price_window for s in stored_setups])
-                    from database.numpy_store import StoredTradeSetup as NumpyStoredTradeSetup
-                    numpy_stored_setups = []
-                    for s in stored_setups:
-                        n_s = NumpyStoredTradeSetup(
-                            id=0,
-                            direction=s.direction,
-                            profit_pct=s.profit_pct,
-                            leverage=s.leverage,
-                            hold_duration=s.hold_duration,
-                            entry_timestamp=s.entry_timestamp,
-                            entry_price=s.entry_price,
-                            exit_price=s.exit_price,
-                            symbol=s.symbol,
-                            timeframe=s.timeframe,
-                            window_size=s.window_size
-                        )
-                        numpy_stored_setups.append(n_s)
-                    ids = state.store.add_batch(embeddings, numpy_stored_setups, price_windows_padded)
-                    state.store.save()
-                    total_inserted += len(ids)
-                    
+                    numpy_stored_setups.append(n_s)
+                ids = state.store.add_batch(embeddings, numpy_stored_setups, price_windows_padded)
+                state.store.save()
+                total_inserted += len(ids)
+                
+            # Briefly yield control to the event loop between symbols
+            await asyncio.sleep(0.05)
+            
         logger.info(f"Auto-population complete. Extracted: {total_extracted}, Inserted/Saved: {total_inserted}")
     except Exception as e:
         logger.error(f"Error during auto-population background task: {e}", exc_info=True)

--- a/services/predict/service.py
+++ b/services/predict/service.py
@@ -48,7 +48,12 @@ CONFIGS = dotdict({
 async def startup_event():
     """Initializes the database connection, loads pre-trained model checkpoints, or performs training if necessary."""
     global model, scaler, model_device
-    checkpoint_dir = "/app/checkpoints"
+    checkpoint_dir = os.environ.get("CHECKPOINT_DIR", "/app/checkpoints")
+    try:
+        os.makedirs(checkpoint_dir, exist_ok=True)
+    except OSError:
+        checkpoint_dir = "./checkpoints"
+        os.makedirs(checkpoint_dir, exist_ok=True)
     checkpoint_path = os.path.join(checkpoint_dir, "WAVESTATE_checkpoint.pth")
     scaler_path = os.path.join(checkpoint_dir, "scaler.pkl")
     


### PR DESCRIPTION
## Summary
Optimized the retrieval of historical candlestick data on the frontend to avoid large queries that can lead to database timeouts and payload transmission issues. Developed a transparent range division algorithm directly in `api.js` that splits query durations into smaller granularity-based sub-ranges, queries them in small concurrent batches, gracefully handles empty chunk responses, and deduplicates and sorts the final consolidated data set.

## Changes
- **api.js:** Update `getCandlestickData` to divide large queries into granularity-based chunks of up to 1000 data points.
- **api.js:** Execute chunk queries in parallel batches using a concurrency limit of 3 requests.
- **api.js:** Deduplicate overlapping data points by timestamp and sort chronologically.
- **api.js:** Handle 404 responses gracefully by treating empty ranges as empty arrays.
- **CandlestickChart.jsx:** Add dropdown selection options for 5s, 15s, and 30s granularities.
- **services/embed/server.py:** Offload heavy database/CPU calculations during auto-population to worker threads to prevent blocking the event loop.
- **services/predict/service.py:** Add a dynamic writable fallback path for model checkpoints to allow running tests locally without permission issues.

## Testing
- [x] Tests pass locally (`PYTHONPATH=src uv run --project src/ pytest tests/`)
- [x] Production asset build runs cleanly (`npm run build`)
- [x] Deduplication, batch concurrent range splitting, sorting, and graceful 404 recovery verified via simulated unit test suite.
