### PR TITLE
fix(embed): resolve Chronos embedding integration and server startup issues

### DIFF
--- a/.agent/core/activeContext.md
+++ b/.agent/core/activeContext.md
@@ -1,26 +1,22 @@
-# Active Context: Online Learning & Setup Archiver
+# Active Context: Chronos Embedding Integration
 
 ## Quick Reference
-- **Feature**: Online Learning & Setup Archiver
-- **Branch**: `feature/retrieval-live-tracking`
-- **Plan File**: `.agent/plans/online-learning-plan.md`
-- **Status**: Execution Phase 🛠️
+- **Feature**: Chronos Embedding Integration
+- **Branch**: `feature/chronos-embedding-fix`
+- **Plan File**: `.agent/plans/chronos-embedding-plan.md`
+- **Status**: Completed ✅
 
 ## Executive Summary
-Implementing dynamic archiving of completed or partially completed forecast runs. When the forecast window completes (or is reset), the frontend sends the price returns and actual outcome to the serve proxy. The backend embeds the history, inserts the setup into PostgreSQL pgvector table, and rebuilds the retrieval index cache dynamically to increase search accuracy.
+Integrated Amazon Chronos (`chronos-t5-base`) into the Trade Setup Embedding service. Resolved critical model initialization, tensor type-casting (bfloat16 to float32 on CPU), and API-to-model dimension mismatch errors. Replaced direct encoder calls with a unified `generate_embedding` method on AppState and TradePipeline, ensuring full backward compatibility for both production and unit tests.
 
-## Key Files to Modify
-- [services/embed/server.py](file:///home/miles/Development/notebooks/CryptoTrading/services/embed/server.py): Add `/setup/add` endpoint.
-- [services/retrieval/main.py](file:///home/miles/Development/notebooks/CryptoTrading/services/retrieval/main.py): Add `/rebuild` endpoint to clear forecaster cache.
-- [services/serve/routers/retrieval.py](file:///home/miles/Development/notebooks/CryptoTrading/services/serve/routers/retrieval.py): Add `/setup/add` proxy endpoint.
-- [frontend/src/components/RetrievalVisualizer.jsx](file:///home/miles/Development/notebooks/CryptoTrading/frontend/src/components/RetrievalVisualizer.jsx): Hook up auto-save triggers and status alerts.
+## Key Files Modified
+- [services/embed/pipeline.py](file:///home/miles/Development/notebooks/CryptoTrading/services/embed/pipeline.py): Fixed model initialization and created `generate_embedding`.
+- [services/embed/server.py](file:///home/miles/Development/notebooks/CryptoTrading/services/embed/server.py): Fixed startup instantiations and routed endpoints through AppState `generate_embedding`.
+- [services/embed/README.md](file:///home/miles/Development/notebooks/CryptoTrading/services/embed/README.md): Documented use of `"use_chronos"`, `"chronos_model_id"`, and `"chronos_torch_dtype"`.
 
-## Acceptance Criteria
-- [ ] Embed service inserts a StoredTradeSetup into pgvector or numpy store.
-- [ ] Retrieval service successfully flushes cache of the given symbol.
-- [ ] Serve router exposes `/api/retrieval/setup/add` proxy.
-- [ ] Frontend triggers setup archive when forecast window is completed or reset.
-- [ ] Frontend displays dynamic database archival success alerts.
+## Next Steps
+- Enable `"use_chronos": true` in production config file if combined 896D embeddings are desired.
+- Set `"embedding_dim": 896` in `config.json` if Chronos is enabled.
 
 
 

--- a/.agent/core/progress.md
+++ b/.agent/core/progress.md
@@ -171,3 +171,13 @@
 - [x] Implement `/setup/add` proxy endpoint in API serve router (`services/serve/routers/retrieval.py`) to process and route setups and trigger cache rebuilds.
 - [x] Implement robust frontend lifecycle auto-archiving (`RetrievalVisualizer.jsx`) supporting full completion saves, interruption saves, and unmount cleanups via refs.
 - [x] Add real-time database sync status badges (`Archiving...`, `Archived ✅`, `Failed ❌`) to the live performance tracking card.
+
+### Phase 25: Chronos Embedding Integration (Completed ✅)
+- [x] Integrate Amazon Chronos (`chronos-t5-base` in `bfloat16`) to the embed service pipeline and server.
+- [x] Fix invalid `ChronosPipeline` constructor call to use `ChronosPipeline.from_pretrained(...)`.
+- [x] Implement a unified `generate_embedding(self, x)` in `TradePipeline` and fallback in `AppState` to support both CNN encoder and optional Chronos embeddings (combined 896D).
+- [x] Add cast to `.float()` before NumPy conversion to support `bfloat16` tensors on CPU and fix copy-construction warning.
+- [x] Replace all direct `state.encoder` embedding calls in endpoints with unified `state.generate_embedding` to ensure correct Chronos integration.
+- [x] Document `"use_chronos"`, `"chronos_model_id"`, and `"chronos_torch_dtype"` configuration parameters and their embedding dimension consequences in `README.md`.
+- [x] Pass all pytest test cases in `tests/test_embed_service.py` and `tests/test_pgvector_store.py`.
+

--- a/services/embed/README.md
+++ b/services/embed/README.md
@@ -194,9 +194,15 @@ Create `config.json` in the api directory:
     "db_port": 5432,
     "db_name": "trade_embeddings",
     "db_user": "postgres",
-    "db_password": "postgres"
+    "db_password": "postgres",
+    "use_chronos": false,
+    "chronos_model_id": "amazon/chronos-t5-base",
+    "chronos_torch_dtype": "bfloat16"
 }
 ```
+
+> [!NOTE]
+> If `"use_chronos": true` is enabled, the 768-dimensional Chronos model embeddings are concatenated with the 128-dimensional CNN encoder embeddings, resulting in an `embedding_dim` of `896`. Ensure `"embedding_dim": 896` is set in the config file in this case.
 
 ## Embedding Details
 

--- a/services/embed/models/chronos.py
+++ b/services/embed/models/chronos.py
@@ -1,0 +1,417 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import warnings
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+from transformers import (
+    AutoConfig,
+    AutoModelForCausalLM,
+    AutoModelForSeq2SeqLM,
+    GenerationConfig,
+    PreTrainedModel,
+)
+
+# Self-import removed to prevent circular import issues
+
+@dataclass
+class ChronosConfig:
+    """
+    This class holds all the configuration parameters to be used
+    by ``ChronosTokenizer`` and ``ChronosModel``.
+    """
+
+    tokenizer_class: str
+    tokenizer_kwargs: Dict[str, Any]
+    context_length: int
+    prediction_length: int
+    n_tokens: int
+    n_special_tokens: int
+    pad_token_id: int
+    eos_token_id: int
+    use_eos_token: bool
+    model_type: Literal["causal", "seq2seq"]
+    num_samples: int
+    temperature: float
+    top_k: int
+    top_p: float
+
+    def __post_init__(self):
+        assert (
+            self.pad_token_id < self.n_special_tokens
+            and self.eos_token_id < self.n_special_tokens
+        ), f"Special token id's must be smaller than {self.n_special_tokens=}"
+
+    def create_tokenizer(self) -> "ChronosTokenizer":
+        class_ = globals()[self.tokenizer_class]
+        return class_(**self.tokenizer_kwargs, config=self)
+
+
+class ChronosTokenizer:
+    """
+    A ``ChronosTokenizer`` definines how time series are mapped into token IDs
+    and back.
+
+    For details, see the ``input_transform`` and ``output_transform`` methods,
+    which concrete classes must implement.
+    """
+
+    def context_input_transform(
+        self,
+        context: torch.Tensor,
+    ) -> Tuple:
+        """
+        Turn a batch of time series into token IDs, attention map, and tokenizer_state.
+
+        Parameters
+        ----------
+        context
+            A tensor shaped (batch_size, time_length), containing the
+            timeseries to forecast. Use left-padding with ``torch.nan``
+            to align time series of different lengths.
+
+        Returns
+        -------
+        token_ids
+            A tensor of integers, shaped (batch_size, time_length + 1)
+            if ``config.use_eos_token`` and (batch_size, time_length)
+            otherwise, containing token IDs for the input series.
+        attention_mask
+            A boolean tensor, same shape as ``token_ids``, indicating
+            which input observations are not ``torch.nan`` (i.e. not
+            missing nor padding).
+        tokenizer_state
+            An object that can be passed to ``label_input_transform``
+            and ``output_transform``. Contains the relevant information
+            to decode output samples into real values,
+            such as location and scale parameters.
+        """
+        raise NotImplementedError()
+
+    def label_input_transform(self, label: torch.Tensor, tokenizer_state: Any) -> Tuple:
+        """
+        Turn a batch of label slices of time series into token IDs and attention map
+        using the ``tokenizer_state`` provided by ``context_input_transform``.
+
+        Parameters
+        ----------
+        context
+            A tensor shaped (batch_size, time_length), containing the
+            timeseries to forecast. Use left-padding with ``torch.nan``
+            to align time series of different lengths.
+        tokenizer_state
+            An object returned by ``context_input_transform`` containing
+            relevant information to preprocess data, such as location and
+            scale. The nature of this depends on the specific tokenizer.
+            This is used for tokenizing the label, in order to use the same
+            scaling used to tokenize the context.
+
+        Returns
+        -------
+        token_ids
+            A tensor of integers, shaped (batch_size, time_length + 1)
+            if ``config.use_eos_token`` and (batch_size, time_length)
+            otherwise, containing token IDs for the input series.
+        attention_mask
+            A boolean tensor, same shape as ``token_ids``, indicating
+            which input observations are not ``torch.nan`` (i.e. not
+            missing nor padding).
+        """
+        raise NotImplementedError()
+
+    def output_transform(
+        self, samples: torch.Tensor, tokenizer_state: Any
+    ) -> torch.Tensor:
+        """
+        Turn a batch of sample token IDs into real values.
+
+        Parameters
+        ----------
+        samples
+            A tensor of integers, shaped (batch_size, num_samples, time_length),
+            containing token IDs of sample trajectories.
+        tokenizer_state
+            An object returned by ``input_transform`` containing
+            relevant context to decode samples, such as location and scale.
+            The nature of this depends on the specific tokenizer.
+
+        Returns
+        -------
+        forecasts
+            A real tensor, shaped (batch_size, num_samples, time_length),
+            containing forecasted sample paths.
+        """
+        raise NotImplementedError()
+
+
+class MeanScaleUniformBins(ChronosTokenizer):
+    def __init__(
+        self, low_limit: float, high_limit: float, config: ChronosConfig
+    ) -> None:
+        self.config = config
+        self.centers = torch.linspace(
+            low_limit,
+            high_limit,
+            config.n_tokens - config.n_special_tokens - 1,
+        )
+        self.boundaries = torch.concat(
+            (
+                torch.tensor([-1e20], device=self.centers.device),
+                (self.centers[1:] + self.centers[:-1]) / 2,
+                torch.tensor([1e20], device=self.centers.device),
+            )
+        )
+
+    def _input_transform(
+        self, context: torch.Tensor, scale: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        attention_mask = ~torch.isnan(context)
+        device = context.device
+        self.boundaries = self.boundaries.to(device)
+
+        if scale is None:
+            scale = torch.nansum(
+                torch.abs(context) * attention_mask, dim=-1
+            ) / torch.nansum(attention_mask, dim=-1)
+            scale[~(scale > 0)] = 1.0
+
+        scaled_context = context / scale.unsqueeze(dim=-1)
+        token_ids = (
+            torch.bucketize(
+                input=scaled_context,
+                boundaries=self.boundaries,
+                # buckets are open to the right, see:
+                # https://pytorch.org/docs/2.1/generated/torch.bucketize.html#torch-bucketize
+                right=True,
+            )
+            + self.config.n_special_tokens
+        )
+
+        token_ids.clamp_(0, self.config.n_tokens - 1)
+
+        token_ids[~attention_mask] = self.config.pad_token_id
+
+        return token_ids, attention_mask, scale
+
+    def _append_eos_token(
+        self, token_ids: torch.Tensor, attention_mask: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        batch_size = token_ids.shape[0]
+        device = token_ids.device
+        eos_tokens = torch.full((batch_size, 1), fill_value=self.config.eos_token_id, device=device)
+        token_ids = torch.concat((token_ids, eos_tokens), dim=1)
+        eos_mask = torch.full((batch_size, 1), fill_value=True, device=device)
+        attention_mask = torch.concat((attention_mask, eos_mask), dim=1)
+
+        return token_ids, attention_mask
+
+    def context_input_transform(
+        self, context: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        length = context.shape[-1]
+
+        if length > self.config.context_length:
+            context = context[..., -self.config.context_length :]
+
+        token_ids, attention_mask, scale = self._input_transform(context=context)
+
+        if self.config.use_eos_token and self.config.model_type == "seq2seq":
+            token_ids, attention_mask = self._append_eos_token(
+                token_ids=token_ids, attention_mask=attention_mask
+            )
+
+        return token_ids, attention_mask, scale
+
+    def label_input_transform(
+        self, label: torch.Tensor, scale: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        length = label.shape[-1]
+
+        assert length == self.config.prediction_length
+        token_ids, attention_mask, _ = self._input_transform(context=label, scale=scale)
+
+        if self.config.use_eos_token:
+            token_ids, attention_mask = self._append_eos_token(
+                token_ids=token_ids, attention_mask=attention_mask
+            )
+
+        return token_ids, attention_mask
+
+    def output_transform(
+        self, samples: torch.Tensor, scale: torch.Tensor
+    ) -> torch.Tensor:
+        device = samples.device
+        scale_unsqueezed = scale.unsqueeze(-1).unsqueeze(-1).to(device)
+        indices = torch.clamp(
+            samples - self.config.n_special_tokens - 1,
+            min=0,
+            max=len(self.centers) - 1,
+        )
+        indices = indices.to(device)
+        self.centers = self.centers.to(device)
+        return self.centers[indices] * scale_unsqueezed
+
+
+class ChronosModel(nn.Module):
+    """
+    A ``ChronosModel`` wraps a ``PreTrainedModel`` object from ``transformers``
+    and uses it to predict sample paths for time series tokens.
+
+    Parameters
+    ----------
+    config
+        The configuration to use.
+    model
+        The pretrained model to use.
+    """
+
+    def __init__(self, config: ChronosConfig, model: PreTrainedModel) -> None:
+        super().__init__()
+        self.config = config
+        self.model = model
+
+    @property
+    def device(self):
+        return self.model.device
+
+    def encode(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ):
+        """
+        Extract the encoder embedding for the given token sequences.
+
+        Parameters
+        ----------
+        input_ids
+            Tensor of indices of input sequence tokens in the vocabulary
+            with shape (batch_size, sequence_length).
+        attention_mask
+            A mask tensor of the same shape as input_ids to avoid attending
+            on padding or missing tokens.
+
+        Returns
+        -------
+        embedding
+            A tensor of encoder embeddings with shape
+            (batch_size, sequence_length, d_model).
+        """
+        assert (
+            self.config.model_type == "seq2seq"
+        ), "Encoder embeddings are only supported for encoder-decoder models"
+        return self.model.encoder(
+            input_ids=input_ids, attention_mask=attention_mask
+        ).last_hidden_state
+
+
+
+def left_pad_and_stack_1D(tensors: List[torch.Tensor]) -> torch.Tensor:
+    max_len = max(len(c) for c in tensors)
+    padded = []
+    for c in tensors:
+        assert isinstance(c, torch.Tensor)
+        assert c.ndim == 1
+        padding = torch.full(
+            size=(max_len - len(c),), fill_value=torch.nan, device=c.device
+        )
+        padded.append(torch.concat((padding, c), dim=-1))
+    return torch.stack(padded)
+
+
+@dataclass
+class ChronosPipeline:
+    """
+    A ``ChronosPipeline`` uses the given tokenizer and model to forecast
+    input time series.
+
+    Use the ``from_pretrained`` class method to load serialized models.
+    Use the ``predict`` method to get forecasts.
+
+    Parameters
+    ----------
+    tokenizer
+        The tokenizer object to use.
+    model
+        The model to use.
+    """
+
+    tokenizer: ChronosTokenizer
+    model: ChronosModel
+
+    def _prepare_and_validate_context(
+        self, context: Union[torch.Tensor, List[torch.Tensor]]
+    ):
+        if isinstance(context, list):
+            context = left_pad_and_stack_1D(context)
+        assert isinstance(context, torch.Tensor)
+        if context.ndim == 1:
+            context = context.unsqueeze(0)
+        assert context.ndim == 2
+
+        return context
+
+    @torch.no_grad()
+    def embed(
+        self, context: Union[torch.Tensor, List[torch.Tensor]]
+    ) -> Tuple[torch.Tensor, Any]:
+        """
+        Get encoder embeddings for the given time series.
+
+        Parameters
+        ----------
+        context
+            Input series. This is either a 1D tensor, or a list
+            of 1D tensors, or a 2D tensor whose first dimension
+            is batch. In the latter case, use left-padding with
+            ``torch.nan`` to align series of different lengths.
+
+        Returns
+        -------
+        embeddings, tokenizer_state
+            A tuple of two tensors: the encoder embeddings and the tokenizer_state,
+            e.g., the scale of the time series in the case of mean scaling.
+            The encoder embeddings are shaped (batch_size, context_length, d_model)
+            or (batch_size, context_length + 1, d_model), where context_length
+            is the size of the context along the time axis if a 2D tensor was provided
+            or the length of the longest time series, if a list of 1D tensors was
+            provided, and the extra 1 is for EOS.
+        """
+        context_tensor = self._prepare_and_validate_context(context=context)
+        token_ids, attention_mask, tokenizer_state = (
+            self.tokenizer.context_input_transform(context_tensor)
+        )
+        embeddings = self.model.encode(
+            input_ids=token_ids.to(self.model.device),
+            attention_mask=attention_mask.to(self.model.device),
+        )
+        return embeddings, tokenizer_state
+
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        """
+        Load the model, either from a local path or from the HuggingFace Hub.
+        Supports the same arguments as ``AutoConfig`` and ``AutoModel``
+        from ``transformers``.
+        """
+
+        config = AutoConfig.from_pretrained(*args, **kwargs)
+
+        assert hasattr(config, "chronos_config"), "Not a Chronos config file"
+
+        chronos_config = ChronosConfig(**config.chronos_config)
+
+        if chronos_config.model_type == "seq2seq":
+            inner_model = AutoModelForSeq2SeqLM.from_pretrained(*args, **kwargs)
+        else:
+            assert chronos_config.model_type == "causal"
+            inner_model = AutoModelForCausalLM.from_pretrained(*args, **kwargs)
+
+        return cls(
+            tokenizer=chronos_config.create_tokenizer(),
+            model=ChronosModel(config=chronos_config, model=inner_model),
+        )

--- a/services/embed/pipeline.py
+++ b/services/embed/pipeline.py
@@ -9,7 +9,7 @@ This module orchestrates:
 5. Generating embeddings for all setups
 6. Storing everything in PostgreSQL with pgvector
 """
-
+import torch
 import numpy as np
 from pathlib import Path
 from typing import Optional, List, Tuple    
@@ -17,12 +17,14 @@ import logging
 import json
 
 from cryptotrading.trade.oracle import DPOracle, LeveragedDPOracle
+from cryptotrading.predict.utils.scale import normalize_context
 from models.encoder import (
     PriceWindowEncoder, 
     TradeSetup, 
     extract_trade_setups
 )
 from models.trainer import EncoderTrainer
+from models.chronos import ChronosPipeline
 from database.numpy_store import NumpyVectorStore, StoredTradeSetup
 
 logging.basicConfig(level=logging.INFO)
@@ -41,19 +43,27 @@ class TradePipeline:
         max_leverage: float = 20.0,
         transaction_cost: float = 0.001,
         store_path: str = "vector_store",
-        oracle_type: str = "leveraged"
+        oracle_type: str = "leveraged",
+        device: str = "cpu",
+        chronos_model_id: str = "amazon/chronos-t5-base",
+        chronos_torch_dtype: str = "bfloat16"
     ):
         self.window_size = window_size
         self.embedding_dim = embedding_dim
         self.max_leverage = max_leverage
         self.transaction_cost = transaction_cost
         self.store_path = store_path
+        self.oracle_type = oracle_type
+        self.device = device
+        self.chronos_model_id = chronos_model_id
+        self.chronos_torch_dtype = chronos_torch_dtype
         
         # Components (initialized lazily)
         self.oracle: Optional[DPOracle | LeveragedDPOracle] = None
         self.encoder: Optional[PriceWindowEncoder] = None
         self.trainer: Optional[EncoderTrainer] = None
         self.store: Optional[NumpyVectorStore] = None
+        self.chronos: Optional[ChronosPipeline] = None
         
     def initialize_oracle(self):
         """Initialize the DP oracle"""
@@ -68,21 +78,34 @@ class TradePipeline:
                 transaction_cost=self.transaction_cost
             )
         logger.info("Oracle initialized")
+
+    def initialize_chronos(self):
+        """Initialize Chronos."""
+        import torch
+        # Map torch dtype string to torch object
+        dtype = torch.bfloat16
+        if self.chronos_torch_dtype == "float16":
+            dtype = torch.float16
+        elif self.chronos_torch_dtype == "float32":
+            dtype = torch.float32
+
+        self.chronos = ChronosPipeline.from_pretrained(
+            self.chronos_model_id,
+            torch_dtype=dtype
+        )
+        self.chronos.model.to(self.device)
+        logger.info(f"Chronos model {self.chronos_model_id} initialized on {self.device}")
         
     def initialize_encoder(self, model_path: Optional[Path] = None):
         """Initialize or load the encoder"""
-        import torch
-        
-        device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        
         self.encoder = PriceWindowEncoder(
             window_size=self.window_size - 1,
             embedding_dim=self.embedding_dim
-        ).to(device)
+        ).to(self.device)
         
         if model_path and model_path.exists():
             self.encoder.load_state_dict(
-                torch.load(model_path, map_location=device)
+                torch.load(model_path, map_location=self.device)
             )
             logger.info(f"Encoder loaded from {model_path}")
         else:
@@ -169,32 +192,71 @@ class TradePipeline:
         
         return history
     
+    def generate_embedding(self, x: np.ndarray) -> np.ndarray:
+        """
+        Generate embedding for a normalized price window or a batch of windows.
+        
+        Args:
+            x: 1D array of shape (window_size - 1,) or 2D array of shape (batch, window_size - 1)
+            
+        Returns:
+            np.ndarray: Embedding vector(s)
+        """
+        if self.encoder is None:
+            raise ValueError("Encoder not initialized")
+            
+        self.encoder.eval()
+        device = next(self.encoder.parameters()).device
+        
+        # Determine if input is 1D or 2D
+        is_single = x.ndim == 1
+        if is_single:
+            x_batch = np.expand_dims(x, axis=0)
+        else:
+            x_batch = x
+            
+        with torch.no_grad():
+            x_tensor = torch.from_numpy(x_batch).float().to(device)
+            # 1. Generate CNN encoder embedding
+            emb = self.encoder(x_tensor).cpu().numpy()
+            
+            # 2. Generate Chronos embedding if chronos is enabled
+            if self.chronos is not None:
+                # Prepare context as a list of 1D arrays
+                context = list(x_batch)
+                # Normalize context to remove DC offset / scale
+                context, _ = normalize_context(context)
+                
+                # Get chronos embeddings (returns Tuple[embeddings, tokenizer_state])
+                chronos_tensor, _ = self.chronos.embed(context)
+                
+                # Mean pool along sequence length (dim=1) and cast to float32 (for numpy compatibility)
+                chronos_emb = chronos_tensor.mean(dim=1).float().cpu().numpy()
+                
+                # Concatenate along feature dimension
+                emb = np.concatenate([emb, chronos_emb], axis=1)
+                
+        if is_single:
+            return emb[0]
+        return emb
+
     def generate_embeddings(
         self,
         setups: List[TradeSetup]
     ) -> np.ndarray:
         """Generate embeddings for all setups"""
-        import torch
-        
         if self.encoder is None:
             raise ValueError("Encoder not initialized")
-        
-        self.encoder.eval()
-        device = next(self.encoder.parameters()).device
-        
+            
         embeddings = []
         batch_size = 256
         
         for i in range(0, len(setups), batch_size):
             batch = setups[i:i + batch_size]
             windows = np.stack([s.price_window for s in batch])
-            
-            with torch.no_grad():
-                x = torch.from_numpy(windows).float().to(device)
-                emb = self.encoder(x).cpu().numpy()
-            
+            emb = self.generate_embedding(windows)
             embeddings.append(emb)
-        
+            
         embeddings = np.vstack(embeddings)
         logger.info(f"Generated {len(embeddings)} embeddings")
         

--- a/services/embed/server.py
+++ b/services/embed/server.py
@@ -467,12 +467,13 @@ async def startup():
         state.config = json.load(f)
 
     state.window_size = state.config.get('window_size', 100)
-    state.embedding_dim = state.config.get('embedding_dim', 128)
+    cnn_dim = state.config.get('embedding_dim', 128)
+    state.embedding_dim = cnn_dim
     
     # Initialize encoder
     state.pipeline = TradePipeline(
         window_size=state.window_size,
-        embedding_dim=state.embedding_dim,
+        embedding_dim=cnn_dim,
         device=state.device,
         chronos_model_id=state.config.get('chronos_model_id', 'amazon/chronos-t5-base'),
         chronos_torch_dtype=state.config.get('chronos_torch_dtype', 'bfloat16')
@@ -487,6 +488,18 @@ async def startup():
     if state.config.get('use_chronos', False):
         logger.info("Initializing Chronos model...")
         state.pipeline.initialize_chronos()
+        
+        # Resolve Chronos dimension dynamically
+        chronos_model = state.pipeline.chronos.model.model
+        if hasattr(chronos_model.config, "d_model"):
+            chronos_dim = chronos_model.config.d_model
+        elif hasattr(chronos_model.config, "hidden_size"):
+            chronos_dim = chronos_model.config.hidden_size
+        else:
+            chronos_dim = 768
+            
+        state.embedding_dim = cnn_dim + chronos_dim
+        logger.info(f"Chronos enabled. Adjusted embedding dimension: {state.embedding_dim} ({cnn_dim} CNN + {chronos_dim} Chronos)")
 
     # Initialize vector store
     db_backend = os.getenv("DB_BACKEND", "numpy").lower()

--- a/services/embed/server.py
+++ b/services/embed/server.py
@@ -27,6 +27,7 @@ import torch
 import logging
 
 from models.encoder import PriceWindowEncoder, normalize_price_window, extract_trade_setups
+from pipeline import TradePipeline
 from database.numpy_store import NumpyVectorStore
 from database.pgvector_store import TradeEmbeddingDB, StoredTradeSetup
 from cryptotrading.trade.oracle import LeveragedDPOracle
@@ -107,6 +108,7 @@ class SearchResponse(BaseModel):
 
 class AppState:
     def __init__(self):
+        self.pipeline: Optional[TradePipeline] = None
         self.encoder: Optional[PriceWindowEncoder] = None
         self.store: Optional[NumpyVectorStore] = None
         self.device: str = 'cuda' if torch.cuda.is_available() else 'cpu'
@@ -115,6 +117,27 @@ class AppState:
         self.config: Dict[str, Any] = {}
         self.active_connections: List[WebSocket] = []
         self.price_buffers: Dict[str, deque] = {}
+
+    def generate_embedding(self, x: np.ndarray) -> np.ndarray:
+        if self.pipeline is not None:
+            return self.pipeline.generate_embedding(x)
+        
+        if self.encoder is None:
+            raise ValueError("Neither pipeline nor encoder is initialized")
+        
+        is_single = x.ndim == 1
+        if is_single:
+            x_batch = np.expand_dims(x, axis=0)
+        else:
+            x_batch = x
+            
+        with torch.no_grad():
+            x_tensor = torch.from_numpy(x_batch).float().to(self.device)
+            emb = self.encoder(x_tensor).cpu().numpy()
+            
+        if is_single:
+            return emb[0]
+        return emb
 
 
 app = FastAPI(
@@ -330,6 +353,7 @@ async def auto_populate_db():
             # Load trained weights
             state.encoder = trainer.encoder
             state.encoder.eval()
+            state.pipeline.encoder = state.encoder
             logger.info(f"Saved trained encoder weights to {model_path}")
             
         # 3. Generate embeddings and insert into vector store
@@ -345,9 +369,7 @@ async def auto_populate_db():
             for i in range(0, len(setups), batch_size):
                 batch = setups[i:i + batch_size]
                 windows = np.stack([s.price_window for s in batch])
-                with torch.no_grad():
-                    x = torch.from_numpy(windows).float().to(device)
-                    emb = state.encoder(x).cpu().numpy()
+                emb = state.generate_embedding(windows)
                 embeddings.append(emb)
                 
             if embeddings:
@@ -432,37 +454,40 @@ async def startup():
     
     # Load config
     config_path = Path("config.json")
-    if config_path.exists():
-        with open(config_path) as f:
-            state.config = json.load(f)
-    else:
-        state.config = {
-            'model_path': 'models/trained/encoder.pt',
-            'store_path': 'vector_store',
-            'window_size': 100,
-            'embedding_dim': 128
-        }
+    if not config_path.exists():
+        with open(config_path, 'w') as f:
+            json.dump({
+                'model_path': 'models/trained/encoder.pt',
+                'store_path': 'vector_store',
+                'window_size': 100,
+                'embedding_dim': 128
+            }, f)
     
+    with open(config_path) as f:
+        state.config = json.load(f)
+
     state.window_size = state.config.get('window_size', 100)
     state.embedding_dim = state.config.get('embedding_dim', 128)
     
     # Initialize encoder
-    state.encoder = PriceWindowEncoder(
-        window_size=state.window_size - 1,
-        embedding_dim=state.embedding_dim
-    ).to(state.device)
+    state.pipeline = TradePipeline(
+        window_size=state.window_size,
+        embedding_dim=state.embedding_dim,
+        device=state.device,
+        chronos_model_id=state.config.get('chronos_model_id', 'amazon/chronos-t5-base'),
+        chronos_torch_dtype=state.config.get('chronos_torch_dtype', 'bfloat16')
+    )
     
+    # Load encoder weights
     model_path = Path(state.config.get('model_path', 'models/trained/encoder.pt'))
-    if model_path.exists():
-        state.encoder.load_state_dict(
-            torch.load(model_path, map_location=state.device)
-        )
-        logger.info(f"Loaded encoder from {model_path}")
-    else:
-        logger.warning(f"No trained model at {model_path}, using random weights")
+    state.pipeline.initialize_encoder(model_path)
+    state.encoder = state.pipeline.encoder
     
-    state.encoder.eval()
-    
+    # Initialize Chronos if requested in config
+    if state.config.get('use_chronos', False):
+        logger.info("Initializing Chronos model...")
+        state.pipeline.initialize_chronos()
+
     # Initialize vector store
     db_backend = os.getenv("DB_BACKEND", "numpy").lower()
     if db_backend == "postgres":
@@ -524,9 +549,7 @@ async def embed_prices(request: EmbedRequest):
     elif len(normalized) > target_len:
         normalized = normalized[-target_len:]
     
-    with torch.no_grad():
-        x = torch.from_numpy(normalized).float().unsqueeze(0).to(state.device)
-        embedding = state.encoder(x).cpu().numpy()[0]
+    embedding = state.generate_embedding(normalized)
     
     return EmbedResponse(
         embedding=embedding.tolist(),
@@ -565,10 +588,8 @@ async def embed_prices_batch(request: BatchEmbedRequest):
     
     for i in range(0, len(x_batch), batch_size):
         sub_batch = x_batch[i:i + batch_size]
-        with torch.no_grad():
-            x = torch.from_numpy(sub_batch).float().to(device)
-            emb = state.encoder(x).cpu().numpy()
-        embeddings.append(emb)
+        embedding = state.generate_embedding(sub_batch)
+        embeddings.append(embedding)
 
     if embeddings:
         embeddings = np.vstack(embeddings)
@@ -597,9 +618,7 @@ async def add_setup(request: AddSetupRequest):
     elif len(normalized) > target_len:
         normalized = normalized[-target_len:]
         
-    with torch.no_grad():
-        x = torch.from_numpy(normalized).float().unsqueeze(0).to(state.device)
-        embedding = state.encoder(x).cpu().numpy()[0]
+    embedding = state.generate_embedding(normalized)
         
     # 2. Re-pad/crop original prices to window_size for storage
     raw_prices = prices
@@ -669,9 +688,7 @@ async def search_similar(request: SearchRequest):
     elif len(normalized) > target_len:
         normalized = normalized[-target_len:]
     
-    with torch.no_grad():
-        x = torch.from_numpy(normalized).float().unsqueeze(0).to(state.device)
-        query_embedding = state.encoder(x).cpu().numpy()[0]
+    query_embedding = state.generate_embedding(normalized)
     
     if isinstance(state.store, TradeEmbeddingDB):
         results = await state.store.search_similar(
@@ -845,9 +862,7 @@ async def websocket_live(websocket: WebSocket, symbol: str):
                     prices = np.array([p[0] for p in buffer])
                     normalized = normalize_price_window(prices)
                     
-                    with torch.no_grad():
-                        x = torch.from_numpy(normalized).float().unsqueeze(0).to(state.device)
-                        query_embedding = state.encoder(x).cpu().numpy()[0]
+                    query_embedding = state.generate_embedding(normalized)
                     
                     if state.store:
                         if isinstance(state.store, TradeEmbeddingDB):

--- a/src/cryptotrading/predict/models/Chronos.py
+++ b/src/cryptotrading/predict/models/Chronos.py
@@ -1,8 +1,8 @@
 import torch
 from torch import nn
-from layers.Transformer_EncDec import Encoder, EncoderLayer
-from layers.SelfAttention_Family import FullAttention, AttentionLayer
-from layers.Embed import PatchEmbedding
+from cryptotrading.predict.layers.Transformer_EncDec import Encoder, EncoderLayer
+from cryptotrading.predict.layers.SelfAttention_Family import FullAttention, AttentionLayer
+from cryptotrading.predict.layers.Embed import PatchEmbedding
 from chronos import BaseChronosPipeline
 
 

--- a/src/cryptotrading/predict/models/Chronos.py
+++ b/src/cryptotrading/predict/models/Chronos.py
@@ -1,0 +1,80 @@
+import torch
+from torch import nn
+from layers.Transformer_EncDec import Encoder, EncoderLayer
+from layers.SelfAttention_Family import FullAttention, AttentionLayer
+from layers.Embed import PatchEmbedding
+from chronos import BaseChronosPipeline
+
+
+class Chronos(nn.Module):
+    def __init__(self, configs, device="cpu"):
+        """
+        patch_len: int, patch len for patch_embedding
+        stride: int, stride for patch_embedding
+        """
+        super().__init__()
+        self.model = BaseChronosPipeline.from_pretrained(
+            "amazon/chronos-bolt-base",
+            device_map=device,  # use "cpu" for CPU inference and "mps" for Apple Silicon
+            torch_dtype=torch.bfloat16,
+        )
+        self.task_name = configs.task_name
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+
+    def forecast(self, x_enc, x_mark_enc, x_dec, x_mark_dec):
+        outputs = []
+        for i in range(x_enc.shape[-1]):
+            output = self.model.predict(x_enc[...,i], prediction_length=self.pred_len)
+            output = output.mean(dim=1)
+            outputs.append(output)
+        dec_out = torch.stack(outputs, dim=-1)
+
+        return dec_out
+
+    def forward(self, x_enc, x_mark_enc, x_dec, x_mark_dec, mask=None):
+        if self.task_name == 'zero_shot_forecast':
+            dec_out = self.forecast(x_enc, x_mark_enc, x_dec, x_mark_dec)
+            return dec_out
+        return None
+
+
+
+class Chronos2(nn.Module):
+    def __init__(self, configs, device="cpu"):
+        """
+        patch_len: int, patch len for patch_embedding
+        stride: int, stride for patch_embedding
+        """
+        super().__init__()
+        self.model = BaseChronosPipeline.from_pretrained(
+            "amazon/chronos-2", 
+            device_map=device
+        )
+        self.task_name = configs.task_name
+        self.seq_len = configs.seq_len
+        self.pred_len = configs.pred_len
+
+    def forecast(self, x_enc, x_mark_enc, x_dec, x_mark_dec):
+        means = x_enc.mean(1, keepdim=True).detach()
+        x_enc = x_enc.sub(means)
+        stdev = torch.sqrt(
+            torch.var(x_enc, dim=1, keepdim=True, unbiased=False) + 1e-5)
+        x_enc = x_enc.div(stdev)
+
+        B, L, C = x_enc.shape
+        x_enc = x_enc.permute(0, 2, 1)
+        quantiles, dec_out = self.model.predict_quantiles(x_enc.cpu().numpy(), prediction_length=self.pred_len, quantile_levels=[0.1, 0.5, 0.9])
+        dec_out = torch.stack(dec_out, dim=0).to(x_enc.device)
+        dec_out= dec_out.permute(0, 2, 1)
+        dec_out = dec_out * \
+                  (stdev[:, 0, :].unsqueeze(1).repeat(1, self.pred_len, 1))
+        dec_out = dec_out + \
+                  (means[:, 0, :].unsqueeze(1).repeat(1, self.pred_len, 1))
+        return dec_out
+
+    def forward(self, x_enc, x_mark_enc, x_dec, x_mark_dec, mask=None):
+        if self.task_name == 'zero_shot_forecast':
+            dec_out = self.forecast(x_enc, x_mark_enc, x_dec, x_mark_dec)
+            return dec_out
+        return None

--- a/src/cryptotrading/predict/utils/scale.py
+++ b/src/cryptotrading/predict/utils/scale.py
@@ -179,7 +179,7 @@ def normalize_context(context_tensor_matrix):
     mean_std_values = []
     normalized_context = []
     for idx, context_tensor in enumerate(context_tensor_matrix):
-        context_tensor = torch.tensor(context_tensor, dtype=torch.float32)
+        context_tensor = torch.as_tensor(context_tensor, dtype=torch.float32)
       
         mask = ~torch.isnan(context_tensor)
         context_mean = context_tensor[mask].mean()

--- a/src/cryptotrading/predict/utils/scale.py
+++ b/src/cryptotrading/predict/utils/scale.py
@@ -154,3 +154,41 @@ class RangeScaler(object):
         x = x.view(s)
         return x
     
+
+
+def min_max_scale(tensor, min_val, max_val):
+    tensor_min = torch.min(tensor)
+    tensor_max = torch.max(tensor)
+    scaled_tensor = (tensor - tensor_min) / (tensor_max - tensor_min) * (max_val - min_val) + min_val
+    return scaled_tensor
+
+def normalize(tensor, mean, std):
+    return (tensor - mean) / std
+
+def denormalize_predictions(predictions, mean_std_values):
+    denormalized_predictions = []
+    for idx, prediction in enumerate(predictions):
+        mean, std = mean_std_values[idx]
+        prediction = prediction * std + mean
+        prediction = torch.nan_to_num(prediction, nan=0.0)
+        denormalized_predictions.append(prediction.cpu().numpy())
+
+    return denormalized_predictions
+
+def normalize_context(context_tensor_matrix):
+    mean_std_values = []
+    normalized_context = []
+    for idx, context_tensor in enumerate(context_tensor_matrix):
+        context_tensor = torch.tensor(context_tensor, dtype=torch.float32)
+      
+        mask = ~torch.isnan(context_tensor)
+        context_mean = context_tensor[mask].mean()
+        context_std = torch.sqrt(((context_tensor[mask] - context_mean) ** 2).mean()) + 1e-7
+        context_tensor = normalize(context_tensor, context_mean, context_std)    
+        
+        normalized_context.append(context_tensor)
+        mean_std_values.append((context_mean, context_std))
+
+    return normalized_context, mean_std_values
+
+


### PR DESCRIPTION
## Summary
Resolved critical model initialization, tensor type-casting (bfloat16 to float32 on CPU), and API-to-model dimension mismatch errors in the newly added Chronos embedding functionality for the embed service.

## Changes
- Replaced direct instantiation of the `ChronosPipeline` dataclass with `ChronosPipeline.from_pretrained(...)`.
- Loaded model on CPU/RAM first, manually moving to `self.device` via `.to(self.device)` to bypass the `accelerate` requirement.
- Added a unified `generate_embedding` method on `TradePipeline` supporting 1D/2D arrays.
- Added a fallback on `AppState.generate_embedding` to maintain backward-compatibility with test suites that set `state.encoder` directly.
- Cast pooled Chronos sequence embeddings to `float32` before NumPy conversion to prevent NumPy BFloat16 type errors on CPU.
- Cleaned up context mapping to pass raw NumPy arrays, suppressing PyTorch warnings.
- Documented use of `"use_chronos"`, `"chronos_model_id"`, and `"chronos_torch_dtype"` in the README.

## Testing
- [x] Pytest suite passes locally (`uv run pytest tests/test_embed_service.py` and `tests/test_pgvector_store.py`)
- [x] Lint/syntax verification successful
- [x] Verification scripts (`verify_embed.py` and `verify_chronos.py`) execute and validate correctly